### PR TITLE
Leverage heterozygosity to create diploid genomes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -694,7 +694,7 @@ jobs:
         if: always()
         run: |
           harpy simulate inversion --quiet --count 10 -z 0.5 test/genome/genome.fasta.gz
-          harpy simulate inversion --quiet --prefix Simulate/invvcf --vcf Simulate/inversion/diploid/sim.inversion.inversion.   hap1.vcf  test/genome/genome.fasta.gz
+          harpy simulate inversion --quiet --prefix Simulate/invvcf --vcf Simulate/inversion/diploid/sim.inversion.inversion.hap1.vcf  test/genome/genome.fasta.gz
       - name: simulate cnv
         shell: micromamba-shell {0}
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -694,19 +694,19 @@ jobs:
         if: always()
         run: |
           harpy simulate inversion --quiet --count 10 -z 0.5 test/genome/genome.fasta.gz
-          harpy simulate inversion --quiet --prefix Simulate/invvcf --vcf Simulate/inversion/diploid/sim.inversion.hap1.vcf  test/genome/genome.fasta.gz
+          harpy simulate inversion --quiet --prefix Simulate/invvcf --vcf Simulate/inversion/diploid/sim.inversion.inversion.   hap1.vcf  test/genome/genome.fasta.gz
       - name: simulate cnv
         shell: micromamba-shell {0}
         if: always()
         run: |
           harpy simulate cnv --quiet --count 10 -z 0.5 test/genome/genome.fasta.gz
-          harpy simulate cnv --quiet --prefix Simulate/cnvvcf --vcf Simulate/cnv/diploid/sim.cnv.hap1.vcf  test/genome/genome.fasta.gz
+          harpy simulate cnv --quiet --prefix Simulate/cnvvcf --vcf Simulate/cnv/diploid/sim.cnv.cnv.hap1.vcf  test/genome/genome.fasta.gz
       - name: simulate translocations
         shell: micromamba-shell {0}
         if: always()
         run: |
           harpy simulate translocation --quiet --count 10 -z 0.5 test/genome/genome.fasta.gz
-          harpy simulate translocation --quiet --prefix Simulate/transvcf --vcf Simulate/translocation/diploid/sim.translocation.hap1.vcf  test/genome/genome.fasta.gz
+          harpy simulate translocation --quiet --prefix Simulate/transvcf --vcf Simulate/translocation/diploid/sim.translocation.translocation.hap1.vcf  test/genome/genome.fasta.gz
 
   simulate_linkedreads:
     needs: [changes, pkgbuild]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -688,25 +688,25 @@ jobs:
         shell: micromamba-shell {0}
         run: |
           harpy simulate snpindel --quiet --snp-count 10 --indel-count 10 -z 0.5  test/genome/genome.fasta.gz
-          harpy simulate snpindel --quiet --prefix Simulate/snpvcf --snp-vcf Simulate/snpindel/sim.snpindel.snp.hap1.vcf --indel-vcf Simulate/snpindel/sim.snpindel.indel.hap1.vcf  test/genome/genome.fasta.gz
+          harpy simulate snpindel --quiet --prefix Simulate/snpvcf --snp-vcf Simulate/snpindel/diploid/sim.snpindel.snp.hap1.vcf --indel-vcf Simulate/snpindel/diploid/sim.snpindel.indel.hap1.vcf  test/genome/genome.fasta.gz
       - name: simulate inversions
         shell: micromamba-shell {0}
         if: always()
         run: |
           harpy simulate inversion --quiet --count 10 -z 0.5 test/genome/genome.fasta.gz
-          harpy simulate inversion --quiet --prefix Simulate/invvcf --vcf Simulate/inversion/sim.inversion.hap1.vcf  test/genome/genome.fasta.gz
+          harpy simulate inversion --quiet --prefix Simulate/invvcf --vcf Simulate/inversion/diploid/sim.inversion.hap1.vcf  test/genome/genome.fasta.gz
       - name: simulate cnv
         shell: micromamba-shell {0}
         if: always()
         run: |
           harpy simulate cnv --quiet --count 10 -z 0.5 test/genome/genome.fasta.gz
-          harpy simulate cnv --quiet --prefix Simulate/cnvvcf --vcf Simulate/cnv/sim.cnv.hap1.vcf  test/genome/genome.fasta.gz
+          harpy simulate cnv --quiet --prefix Simulate/cnvvcf --vcf Simulate/cnv/diploid/sim.cnv.hap1.vcf  test/genome/genome.fasta.gz
       - name: simulate translocations
         shell: micromamba-shell {0}
         if: always()
         run: |
           harpy simulate translocation --quiet --count 10 -z 0.5 test/genome/genome.fasta.gz
-          harpy simulate translocation --quiet --prefix Simulate/transvcf --vcf Simulate/translocation/sim.translocation.hap1.vcf  test/genome/genome.fasta.gz
+          harpy simulate translocation --quiet --prefix Simulate/transvcf --vcf Simulate/translocation/diploid/sim.translocation.hap1.vcf  test/genome/genome.fasta.gz
 
   simulate_linkedreads:
     needs: [changes, pkgbuild]

--- a/harpy/simulate.py
+++ b/harpy/simulate.py
@@ -72,7 +72,11 @@ docstring = {
         },
         {
             "name": "Random Variants",
-            "options": ["--centromeres", "--count", "--exclude-chr", "--genes", "--heterozygosity", "--max-size", "--min-size"],
+            "options": ["--centromeres", "--count", "--exclude-chr", "--genes", "--max-size", "--min-size"],
+        },
+        {
+            "name": "Diploid Options",
+            "options": ["--heterozygosity", "--only-vcf"],
         },
         {
             "name": "Workflow Controls",
@@ -86,7 +90,11 @@ docstring = {
         },
         {
             "name": "Random Variants",
-            "options": ["--centromeres", "--count", "--dup-ratio", "--exclude-chr", "--gain-ratio", "--genes", "--heterozygosity",  "--max-copy", "--max-size", "--min-size"],
+            "options": ["--centromeres", "--count", "--dup-ratio", "--exclude-chr", "--gain-ratio", "--genes",  "--max-copy", "--max-size", "--min-size"],
+        },
+        {
+            "name": "Diploid Options",
+            "options": ["--heterozygosity", "--only-vcf"],
         },
         {
             "name": "Workflow Controls",
@@ -100,7 +108,11 @@ docstring = {
         },
         {
             "name": "Random Variants",
-            "options": ["--centromeres", "--count", "--exclude-chr", "--genes", "--heterozygosity"],
+            "options": ["--centromeres", "--count", "--exclude-chr", "--genes"],
+        },
+        {
+            "name": "Diploid Options",
+            "options": ["--heterozygosity", "--only-vcf"],
         },
         {
             "name": "Workflow Controls",
@@ -204,7 +216,7 @@ def linkedreads(genome_hap1, genome_hap2, output_dir, outer_distance, mutation_r
 @click.option('-y', '--snp-gene-constraints', type = click.Choice(["noncoding", "coding", "2d", "4d"]), help = "How to constrain randomly simulated SNPs {`noncoding`,`coding`,`2d`,`4d`}")
 @click.option('-g', '--genes', type = click.Path(exists=True, readable=True), help = "GFF3 file of genes to use with `--snp-gene-constraints`")
 @click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = 'heterozygosity to simulate diploid variants')
-@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the VCF rather than the fasta files')
+@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the vcf rather than the fasta files')
 @click.option('-e', '--exclude-chr', type = click.Path(exists=True, dir_okay=False, readable=True), help = "Text file of chromosomes to avoid")
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Simulate/snpindel", show_default=True,  help = 'Output directory name')
 @click.option('-p', '--prefix', type = str, default= "sim.snpindel", show_default=True, help = "Naming prefix for output files")
@@ -330,7 +342,7 @@ def snpindel(genome, snp_vcf, indel_vcf, only_vcf, output_dir, prefix, snp_count
 @click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = 'heterozygosity to simulate diploid variants')
 @click.option('-e', '--exclude-chr', type = click.Path(exists=True, dir_okay=False, readable=True), help = "Text file of chromosomes to avoid")
 @click.option('-p', '--prefix', type = str, default= "sim.inversion", show_default=True, help = "Naming prefix for output files")
-@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the VCF rather than the fasta files')
+@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the vcf rather than the fasta files')
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Simulate/inversion", show_default=True,  help = 'Output directory name')
 @click.option('--conda',  is_flag = True, default = False, help = 'Use conda/mamba instead of container')
 @click.option('--setup-only',  is_flag = True, hidden = True, show_default = True, default = False, help = 'Setup the workflow and exit')
@@ -437,7 +449,7 @@ def inversion(genome, vcf, only_vcf, prefix, output_dir, count, min_size, max_si
 @click.option('-c', '--centromeres', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of centromeres to avoid")
 @click.option('-g', '--genes', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of genes to avoid when simulating (requires `--snp-coding-partition` for SNPs)")
 @click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = 'heterozygosity to simulate diploid variants')
-@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the VCF rather than the fasta files')
+@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the vcf rather than the fasta files')
 @click.option('-e', '--exclude-chr', type = click.Path(exists=True, dir_okay=False, readable=True), help = "Text file of chromosomes to avoid")
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Simulate/cnv", show_default=True,  help = 'Output directory name')
 @click.option('-p', '--prefix', type = str, default= "sim.cnv", show_default=True, help = "Naming prefix for output files")
@@ -549,7 +561,7 @@ def cnv(genome, output_dir, vcf, only_vcf, prefix, count, min_size, max_size, du
 @click.option('-c', '--centromeres', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of centromeres to avoid")
 @click.option('-g', '--genes', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of genes to avoid when simulating")
 @click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = 'heterozygosity to simulate diploid variants')
-@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the VCF rather than the fasta files')
+@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the vcf rather than the fasta files')
 @click.option('-e', '--exclude-chr', type = click.Path(exists=True, dir_okay=False, readable=True), help = "Text file of chromosomes to avoid")
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Simulate/translocation", show_default=True,  help = 'Output directory name')
 @click.option('-p', '--prefix', type = str, default= "sim.translocation", show_default=True, help = "Naming prefix for output files")

--- a/harpy/simulate.py
+++ b/harpy/simulate.py
@@ -523,6 +523,7 @@ def cnv(genome, output_dir, vcf, only_vcf, prefix, count, min_size, max_size, du
         config.write(f"output_directory: {output_dir}\n")
         config.write("variant_type: cnv\n")
         config.write(f"prefix: {prefix}\n")
+        config.write(f"random_seed: {randomseed}\n") if randomseed else None
         config.write("heterozygosity:\n")
         config.write(f"  value: {heterozygosity}\n")
         config.write(f"  only_vcf: {only_vcf}\n")
@@ -533,7 +534,6 @@ def cnv(genome, output_dir, vcf, only_vcf, prefix, count, min_size, max_size, du
             config.write(f"dup_ratio: {dup_ratio}\n") if dup_ratio else None
             config.write(f"cnv_max_copy: {max_copy}\n") if max_copy else None
             config.write(f"gain_ratio: {gain_ratio}\n") if gain_ratio else None
-            config.write(f"random_seed: {randomseed}\n") if randomseed else None
         config.write(f"workflow_call: {command}\n")
         config.write("inputs:\n")
         config.write(f"  genome: {Path(genome).resolve()}\n")
@@ -628,9 +628,9 @@ def translocation(genome, output_dir, prefix, vcf, only_vcf, count, centromeres,
         config.write(f"output_directory: {output_dir}\n")
         config.write("variant_type: translocation\n")
         config.write(f"prefix: {prefix}\n")
+        config.write(f"random_seed: {randomseed}\n") if randomseed else None
         if not vcf:
             config.write(f"count: {count}\n")
-            config.write(f"random_seed: {randomseed}\n") if randomseed else None
         config.write("heterozygosity:\n")
         config.write(f"  value: {heterozygosity}\n")
         config.write(f"  only_vcf: {only_vcf}\n")

--- a/harpy/simulate.py
+++ b/harpy/simulate.py
@@ -312,7 +312,7 @@ def snpindel(genome, snp_vcf, indel_vcf, only_vcf, output_dir, prefix, snp_count
             config.write(f"indel_ratio: {indel_ratio}\n") if indel_ratio else None
             config.write(f"indel_size_alpha: {indel_size_alpha}\n") if indel_size_alpha else None
             config.write(f"indel_size_constant: {indel_size_constant}\n") if indel_size_constant else None
-        config.write(f"randomseed: {randomseed}\n") if randomseed else None
+        config.write(f"random_seed: {randomseed}\n") if randomseed else None
         config.write(f"workflow_call: {command}\n")
         config.write("inputs:\n")
         config.write(f"  genome: {Path(genome).resolve()}\n")
@@ -418,7 +418,7 @@ def inversion(genome, vcf, only_vcf, prefix, output_dir, count, min_size, max_si
             config.write(f"count: {count}\n")
             config.write(f"min_size: {min_size}\n") if min_size else None
             config.write(f"max_size: {max_size}\n") if max_size else None
-            config.write(f"randomseed: {randomseed}\n") if randomseed else None
+            config.write(f"random_seed: {randomseed}\n") if randomseed else None
         config.write(f"workflow_call: {command}\n")
         config.write("inputs:\n")
         config.write(f"  genome: {Path(genome).resolve()}\n")
@@ -536,7 +536,7 @@ def cnv(genome, output_dir, vcf, only_vcf, prefix, count, min_size, max_size, du
             config.write(f"dup_ratio: {dup_ratio}\n") if dup_ratio else None
             config.write(f"cnv_max_copy: {max_copy}\n") if max_copy else None
             config.write(f"gain_ratio: {gain_ratio}\n") if gain_ratio else None
-            config.write(f"randomseed: {randomseed}\n") if randomseed else None
+            config.write(f"random_seed: {randomseed}\n") if randomseed else None
         config.write(f"workflow_call: {command}\n")
         config.write("inputs:\n")
         config.write(f"  genome: {Path(genome).resolve()}\n")
@@ -634,7 +634,7 @@ def translocation(genome, output_dir, prefix, vcf, only_vcf, count, centromeres,
         config.write(f"prefix: {prefix}\n")
         if not vcf:
             config.write(f"count: {count}\n")
-            config.write(f"randomseed: {randomseed}\n") if randomseed else None
+            config.write(f"random_seed: {randomseed}\n") if randomseed else None
         config.write("heterozygosity:\n")
         config.write(f"  value: {heterozygosity}\n")
         config.write(f"  only_vcf: {only_vcf}\n")

--- a/harpy/simulate.py
+++ b/harpy/simulate.py
@@ -320,7 +320,6 @@ def snpindel(genome, snp_vcf, indel_vcf, only_vcf, output_dir, prefix, snp_count
     start_text.add_row("Workflow Log:", sm_log.replace(f"{output_dir}/", "") + "[dim].gz")
     launch_snakemake(command, "simulate_snpindel", start_text, output_dir, sm_log, quiet)
 
-
 @click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Please See the documentation for more information: https://pdimens.github.io/harpy/modules/simulate/simulate-variants")
 @click.option('-v', '--vcf', type=click.Path(exists=True, dir_okay=False, readable=True), help = 'VCF file of known inversions to simulate')
 @click.option('-n', '--count', type = click.IntRange(min = 0), default=0, show_default=False, help = "Number of random inversions to simluate")
@@ -328,9 +327,10 @@ def snpindel(genome, snp_vcf, indel_vcf, only_vcf, output_dir, prefix, snp_count
 @click.option('-x', '--max-size', type = click.IntRange(min = 1), default = 100000, show_default= True, help = "Maximum inversion size (bp)")
 @click.option('-c', '--centromeres', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of centromeres to avoid")
 @click.option('-g', '--genes', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of genes to avoid when simulating")
-@click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = '% heterozygosity to simulate diploid later')
+@click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = 'heterozygosity to simulate diploid variants')
 @click.option('-e', '--exclude-chr', type = click.Path(exists=True, dir_okay=False, readable=True), help = "Text file of chromosomes to avoid")
 @click.option('-p', '--prefix', type = str, default= "sim.inversion", show_default=True, help = "Naming prefix for output files")
+@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the VCF rather than the fasta files')
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Simulate/inversion", show_default=True,  help = 'Output directory name')
 @click.option('--conda',  is_flag = True, default = False, help = 'Use conda/mamba instead of container')
 @click.option('--setup-only',  is_flag = True, hidden = True, show_default = True, default = False, help = 'Setup the workflow and exit')
@@ -339,14 +339,17 @@ def snpindel(genome, snp_vcf, indel_vcf, only_vcf, output_dir, prefix, snp_count
 @click.option('--randomseed', type = click.IntRange(min = 1), help = "Random seed for simulation")
 @click.option('--snakemake', type = str, help = 'Additional Snakemake parameters, in quotes')
 @click.argument('genome', required=True, type=click.Path(exists=True, dir_okay=False, readable=True), nargs=1)
-def inversion(genome, vcf, prefix, output_dir, count, min_size, max_size, centromeres, genes, heterozygosity, exclude_chr, randomseed, snakemake, quiet, hpc, conda, setup_only):
+def inversion(genome, vcf, only_vcf, prefix, output_dir, count, min_size, max_size, centromeres, genes, heterozygosity, exclude_chr, randomseed, snakemake, quiet, hpc, conda, setup_only):
     """
     Introduce inversions into a genome
  
-    Create a haploid genome with inversions introduced into it. Use either a VCF file to simulate known inversions
-    or the command line options listed below to simulate random inversions. Setting `--heterozygosity` greater
-    than `0` will also create a subsampled VCF file with which you can create another simulated genome (diploid)
-    by running this module again.
+    ### Haploid
+    Use either a VCF file to simulate known inversions or the command line options listed below to simulate random inversions.
+
+    ### Diploid
+    Setting `--heterozygosity` greater than `0` will create homozygotes and heterozygotes from the simulated variants and
+    create a diploid genome with these variants. Use `--only-vcf` with `--heterozygosity` to only produce the diploid variant VCF file(s)
+    rather than the diploid genome.
     """
     if not vcf and count == 0:
         print_error("missing option", "Provide either a `--count` of cnv to randomly simulate or a `--vcf` of known variants to simulate.")
@@ -396,7 +399,9 @@ def inversion(genome, vcf, prefix, output_dir, count, min_size, max_size, centro
         config.write(f"output_directory: {output_dir}\n")
         config.write("variant_type: inversion\n")
         config.write(f"prefix: {prefix}\n")
-        config.write(f"heterozygosity: {heterozygosity}\n")
+        config.write("heterozygosity:\n")
+        config.write(f"  value: {heterozygosity}\n")
+        config.write(f"  only_vcf: {only_vcf}\n")
         if not vcf:
             config.write(f"count: {count}\n")
             config.write(f"min_size: {min_size}\n") if min_size else None
@@ -431,7 +436,8 @@ def inversion(genome, vcf, prefix, output_dir, count, min_size, max_size, centro
 @click.option('-y', '--max-copy', type = click.IntRange(min = 1), default=10, show_default=True, help = "Maximum number of copies")
 @click.option('-c', '--centromeres', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of centromeres to avoid")
 @click.option('-g', '--genes', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of genes to avoid when simulating (requires `--snp-coding-partition` for SNPs)")
-@click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = '% heterozygosity to simulate diploid later')
+@click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = 'heterozygosity to simulate diploid variants')
+@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the VCF rather than the fasta files')
 @click.option('-e', '--exclude-chr', type = click.Path(exists=True, dir_okay=False, readable=True), help = "Text file of chromosomes to avoid")
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Simulate/cnv", show_default=True,  help = 'Output directory name')
 @click.option('-p', '--prefix', type = str, default= "sim.cnv", show_default=True, help = "Naming prefix for output files")
@@ -442,15 +448,18 @@ def inversion(genome, vcf, prefix, output_dir, count, min_size, max_size, centro
 @click.option('--randomseed', type = click.IntRange(min = 1), help = "Random seed for simulation")
 @click.option('--snakemake', type = str, help = 'Additional Snakemake parameters, in quotes')
 @click.argument('genome', required=True, type=click.Path(exists=True, dir_okay=False, readable=True), nargs=1)
-def cnv(genome, output_dir, vcf, prefix, count, min_size, max_size, dup_ratio, max_copy, gain_ratio, centromeres, genes, heterozygosity, exclude_chr, randomseed, snakemake, quiet, hpc, conda, setup_only):
+def cnv(genome, output_dir, vcf, only_vcf, prefix, count, min_size, max_size, dup_ratio, max_copy, gain_ratio, centromeres, genes, heterozygosity, exclude_chr, randomseed, snakemake, quiet, hpc, conda, setup_only):
     """
     Introduce copy number variants into a genome
  
-    Create a haploid genome with copy number variants introduced into it. Use either a VCF file to simulate known CNVs
-    or the command line options listed below to simulate random variants of the selected type. Setting `--heterozygosity` greater
-    than `0` will also create a subsampled VCF file with which you can create another simulated genome (diploid)
-    by running this module again.
-
+    ### Haploid
+    Use either a VCF file to simulate known CNVs or the command line options listed below to simulate random CNVs.
+      
+    ### Diploid
+    Setting `--heterozygosity` greater than `0` will create homozygotes and heterozygotes from the simulated variants and
+    create a diploid genome with these variants. Use `--only-vcf` with `--heterozygosity` to only produce the diploid variant VCF file(s)
+    rather than the diploid genome.
+ 
     The two ratio parameters control different things and have special meanings when setting their value to either `9999` or `0`:
     
     | ratio | meaning | `9999` | `0` |
@@ -505,7 +514,9 @@ def cnv(genome, output_dir, vcf, prefix, count, min_size, max_size, dup_ratio, m
         config.write(f"output_directory: {output_dir}\n")
         config.write("variant_type: cnv\n")
         config.write(f"prefix: {prefix}\n")
-        config.write(f"heterozygosity: {heterozygosity}\n")
+        config.write("heterozygosity:\n")
+        config.write(f"  value: {heterozygosity}\n")
+        config.write(f"  only_vcf: {only_vcf}\n")
         if not vcf:
             config.write(f"count: {count}\n")
             config.write(f"min_size: {min_size}\n") if min_size else None
@@ -537,7 +548,8 @@ def cnv(genome, output_dir, vcf, prefix, count, min_size, max_size, dup_ratio, m
 @click.option('-n', '--count', type = click.IntRange(min = 0), default=0, show_default=False, help = "Number of random translocations to simluate")
 @click.option('-c', '--centromeres', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of centromeres to avoid")
 @click.option('-g', '--genes', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of genes to avoid when simulating")
-@click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = '% heterozygosity to simulate diploid later')
+@click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = 'heterozygosity to simulate diploid variants')
+@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the VCF rather than the fasta files')
 @click.option('-e', '--exclude-chr', type = click.Path(exists=True, dir_okay=False, readable=True), help = "Text file of chromosomes to avoid")
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Simulate/translocation", show_default=True,  help = 'Output directory name')
 @click.option('-p', '--prefix', type = str, default= "sim.translocation", show_default=True, help = "Naming prefix for output files")
@@ -548,15 +560,17 @@ def cnv(genome, output_dir, vcf, prefix, count, min_size, max_size, dup_ratio, m
 @click.option('--randomseed', type = click.IntRange(min = 1), help = "Random seed for simulation")
 @click.option('--snakemake', type = str, help = 'Additional Snakemake parameters, in quotes')
 @click.argument('genome', required=True, type=click.Path(exists=True, dir_okay=False, readable=True), nargs=1)
-def translocation(genome, output_dir, prefix, vcf, count, centromeres, genes, heterozygosity, exclude_chr, randomseed, snakemake, quiet, hpc, conda, setup_only):
+def translocation(genome, output_dir, prefix, vcf, only_vcf, count, centromeres, genes, heterozygosity, exclude_chr, randomseed, snakemake, quiet, hpc, conda, setup_only):
     """
     Introduce transolcations into a genome
  
-    Create a haploid genome with translocations introduced into it. Use either a VCF file to 
-    simulate known translocations or the command line options listed below to simulate random
-    variants of the selected type. Setting `--heterozygosity` greater than `0` will also create
-    a subsampled VCF file with which you can create another simulated genome (diploid) by running
-    this module again.
+    ### Haploid
+    Use either a VCF file to simulate known translocations or the command line options listed below to simulate random translocations.
+      
+    ### Diploid
+    Setting `--heterozygosity` greater than `0` will create homozygotes and heterozygotes from the simulated variants and
+    create a diploid genome with these variants. Use `--only-vcf` with `--heterozygosity` to only produce the diploid variant VCF file(s)
+    rather than the diploid genome.
     """
     if not vcf and count == 0:
         print_error("missing option", "Provide either a `--count` of cnv to randomly simulate or a `--vcf` of known cnv to simulate.")
@@ -609,7 +623,9 @@ def translocation(genome, output_dir, prefix, vcf, count, centromeres, genes, he
         if not vcf:
             config.write(f"count: {count}\n")
             config.write(f"randomseed: {randomseed}\n") if randomseed else None
-        config.write(f"heterozygosity: {heterozygosity}\n")
+        config.write("heterozygosity:\n")
+        config.write(f"  value: {heterozygosity}\n")
+        config.write(f"  only_vcf: {only_vcf}\n")
         config.write(f"workflow_call: {command}\n")
         config.write("inputs:\n")
         config.write(f"  genome: {Path(genome).resolve()}\n")

--- a/harpy/simulate.py
+++ b/harpy/simulate.py
@@ -571,7 +571,7 @@ def cnv(genome, output_dir, vcf, only_vcf, prefix, count, min_size, max_size, du
 @click.argument('genome', required=True, type=click.Path(exists=True, dir_okay=False, readable=True), nargs=1)
 def translocation(genome, output_dir, prefix, vcf, only_vcf, count, centromeres, genes, heterozygosity, exclude_chr, randomseed, snakemake, quiet, hpc, conda, setup_only):
     """
-    Introduce transolcations into a genome
+    Introduce translocations into a genome
  
     ### Haploid
     Use either a VCF file to simulate known translocations or the command line options listed below to simulate random translocations.

--- a/harpy/simulate.py
+++ b/harpy/simulate.py
@@ -216,7 +216,7 @@ def linkedreads(genome_hap1, genome_hap2, output_dir, outer_distance, mutation_r
 @click.option('-y', '--snp-gene-constraints', type = click.Choice(["noncoding", "coding", "2d", "4d"]), help = "How to constrain randomly simulated SNPs {`noncoding`,`coding`,`2d`,`4d`}")
 @click.option('-g', '--genes', type = click.Path(exists=True, readable=True), help = "GFF3 file of genes to use with `--snp-gene-constraints`")
 @click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = 'heterozygosity to simulate diploid variants')
-@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the vcf rather than the fasta files')
+@click.option('--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the vcf rather than the fasta files')
 @click.option('-e', '--exclude-chr', type = click.Path(exists=True, dir_okay=False, readable=True), help = "Text file of chromosomes to avoid")
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Simulate/snpindel", show_default=True,  help = 'Output directory name')
 @click.option('-p', '--prefix', type = str, default= "sim.snpindel", show_default=True, help = "Naming prefix for output files")
@@ -236,9 +236,8 @@ def snpindel(genome, snp_vcf, indel_vcf, only_vcf, output_dir, prefix, snp_count
     to simulate random variants of the selected type.
     
     ### Diploid
-    Setting `--heterozygosity` greater than `0` will create homozygotes and heterozygotes from the simulated variants and
-    create a diploid genome with these variants. Use `--only-vcf` with `--heterozygosity` to only produce the diploid variant VCF file(s)
-    rather than the diploid genome.
+    To simulate a diploid genome with heterozygous and homozygous variants, set `--heterozygosity` to a value greater than `0`.
+    Use `--only-vcf` alongside `--heterozygosity` if you want to generate only the variant VCF file(s) without creating the diploid genome.
     
     The ratio parameters control different things for snp and indel variants and have special
     meanings when setting the value to either `9999` or `0` :
@@ -342,7 +341,7 @@ def snpindel(genome, snp_vcf, indel_vcf, only_vcf, output_dir, prefix, snp_count
 @click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = 'heterozygosity to simulate diploid variants')
 @click.option('-e', '--exclude-chr', type = click.Path(exists=True, dir_okay=False, readable=True), help = "Text file of chromosomes to avoid")
 @click.option('-p', '--prefix', type = str, default= "sim.inversion", show_default=True, help = "Naming prefix for output files")
-@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the vcf rather than the fasta files')
+@click.option('--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the vcf rather than the fasta files')
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Simulate/inversion", show_default=True,  help = 'Output directory name')
 @click.option('--conda',  is_flag = True, default = False, help = 'Use conda/mamba instead of container')
 @click.option('--setup-only',  is_flag = True, hidden = True, show_default = True, default = False, help = 'Setup the workflow and exit')
@@ -359,9 +358,8 @@ def inversion(genome, vcf, only_vcf, prefix, output_dir, count, min_size, max_si
     Use either a VCF file to simulate known inversions or the command line options listed below to simulate random inversions.
 
     ### Diploid
-    Setting `--heterozygosity` greater than `0` will create homozygotes and heterozygotes from the simulated variants and
-    create a diploid genome with these variants. Use `--only-vcf` with `--heterozygosity` to only produce the diploid variant VCF file(s)
-    rather than the diploid genome.
+    To simulate a diploid genome with heterozygous and homozygous variants, set `--heterozygosity` to a value greater than `0`.
+    Use `--only-vcf` alongside `--heterozygosity` if you want to generate only the variant VCF file(s) without creating the diploid genome.
     """
     if not vcf and count == 0:
         print_error("missing option", "Provide either a `--count` of cnv to randomly simulate or a `--vcf` of known variants to simulate.")
@@ -414,11 +412,11 @@ def inversion(genome, vcf, only_vcf, prefix, output_dir, count, min_size, max_si
         config.write("heterozygosity:\n")
         config.write(f"  value: {heterozygosity}\n")
         config.write(f"  only_vcf: {only_vcf}\n")
+        config.write(f"random_seed: {randomseed}\n") if randomseed else None
         if not vcf:
             config.write(f"count: {count}\n")
             config.write(f"min_size: {min_size}\n") if min_size else None
             config.write(f"max_size: {max_size}\n") if max_size else None
-            config.write(f"random_seed: {randomseed}\n") if randomseed else None
         config.write(f"workflow_call: {command}\n")
         config.write("inputs:\n")
         config.write(f"  genome: {Path(genome).resolve()}\n")
@@ -449,7 +447,7 @@ def inversion(genome, vcf, only_vcf, prefix, output_dir, count, min_size, max_si
 @click.option('-c', '--centromeres', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of centromeres to avoid")
 @click.option('-g', '--genes', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of genes to avoid when simulating (requires `--snp-coding-partition` for SNPs)")
 @click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = 'heterozygosity to simulate diploid variants')
-@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the vcf rather than the fasta files')
+@click.option('--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the vcf rather than the fasta files')
 @click.option('-e', '--exclude-chr', type = click.Path(exists=True, dir_okay=False, readable=True), help = "Text file of chromosomes to avoid")
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Simulate/cnv", show_default=True,  help = 'Output directory name')
 @click.option('-p', '--prefix', type = str, default= "sim.cnv", show_default=True, help = "Naming prefix for output files")
@@ -468,9 +466,8 @@ def cnv(genome, output_dir, vcf, only_vcf, prefix, count, min_size, max_size, du
     Use either a VCF file to simulate known CNVs or the command line options listed below to simulate random CNVs.
       
     ### Diploid
-    Setting `--heterozygosity` greater than `0` will create homozygotes and heterozygotes from the simulated variants and
-    create a diploid genome with these variants. Use `--only-vcf` with `--heterozygosity` to only produce the diploid variant VCF file(s)
-    rather than the diploid genome.
+    To simulate a diploid genome with heterozygous and homozygous variants, set `--heterozygosity` to a value greater than `0`.
+    Use `--only-vcf` alongside `--heterozygosity` if you want to generate only the variant VCF file(s) without creating the diploid genome.
  
     The two ratio parameters control different things and have special meanings when setting their value to either `9999` or `0`:
     
@@ -561,7 +558,7 @@ def cnv(genome, output_dir, vcf, only_vcf, prefix, count, min_size, max_size, du
 @click.option('-c', '--centromeres', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of centromeres to avoid")
 @click.option('-g', '--genes', type = click.Path(exists=True, dir_okay=False, readable=True), help = "GFF3 file of genes to avoid when simulating")
 @click.option('-z', '--heterozygosity', type = click.FloatRange(0,1), default = 0, show_default=True, help = 'heterozygosity to simulate diploid variants')
-@click.option('-v', '--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the vcf rather than the fasta files')
+@click.option('--only-vcf',  is_flag = True, default = False, help = 'If setting heterozygosity, only create the vcf rather than the fasta files')
 @click.option('-e', '--exclude-chr', type = click.Path(exists=True, dir_okay=False, readable=True), help = "Text file of chromosomes to avoid")
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Simulate/translocation", show_default=True,  help = 'Output directory name')
 @click.option('-p', '--prefix', type = str, default= "sim.translocation", show_default=True, help = "Naming prefix for output files")
@@ -580,9 +577,8 @@ def translocation(genome, output_dir, prefix, vcf, only_vcf, count, centromeres,
     Use either a VCF file to simulate known translocations or the command line options listed below to simulate random translocations.
       
     ### Diploid
-    Setting `--heterozygosity` greater than `0` will create homozygotes and heterozygotes from the simulated variants and
-    create a diploid genome with these variants. Use `--only-vcf` with `--heterozygosity` to only produce the diploid variant VCF file(s)
-    rather than the diploid genome.
+    To simulate a diploid genome with heterozygous and homozygous variants, set `--heterozygosity` to a value greater than `0`.
+    Use `--only-vcf` alongside `--heterozygosity` if you want to generate only the variant VCF file(s) without creating the diploid genome.
     """
     if not vcf and count == 0:
         print_error("missing option", "Provide either a `--count` of cnv to randomly simulate or a `--vcf` of known cnv to simulate.")

--- a/harpy/snakefiles/simulate_snpindel.smk
+++ b/harpy/snakefiles/simulate_snpindel.smk
@@ -104,7 +104,7 @@ rule simulate_haploid:
     shell:
         "perl {params.simuG} -refseq {input.geno} -prefix {params.prefix} {params.parameters} > {log}"
 
-rule heterozygous_snps:
+rule diploid_snps:
     input:
         f"{outdir}/{outprefix}.snp.vcf"
     output:
@@ -135,7 +135,7 @@ rule heterozygous_snps:
                     else:
                         hap2.write(line)
 
-use rule heterozygous_snps as heterozygous_indels with:
+use rule diploid_snps as diploid_indels with:
     input:
         f"{outdir}/{outprefix}.indel.vcf"
     output:

--- a/harpy/snakefiles/simulate_snpindel.smk
+++ b/harpy/snakefiles/simulate_snpindel.smk
@@ -111,10 +111,9 @@ rule diploid_snps:
         f"{outdir}/diploid/{outprefix}.snp.hap1.vcf",
         f"{outdir}/diploid/{outprefix}.snp.hap2.vcf"
     params:
-        heterozygosity
+        het = heterozygosity
     run:
-        if randomseed:
-            random.seed(randomseed)
+        rng = random.Random(randomseed) if randomseed else random.Random()
         with open(input[0], "r") as in_vcf, open(output[0], "w") as hap1, open(output[1], "w") as hap2:
             while True:
                 line = in_vcf.readline()
@@ -124,13 +123,13 @@ rule diploid_snps:
                     hap1.write(line)
                     hap2.write(line)
                     continue
-                if random.uniform(0, 1) >= params[0]:
+                if rng.uniform(0, 1) >= params.het:
                     # write homozygote
                     hap1.write(line)
                     hap2.write(line)
                 else:
                     # 50% chance of falling into hap1 or hap2
-                    if random.uniform(0, 1) >= 0.5:
+                    if rng.uniform(0, 1) >= 0.5:
                         hap1.write(line)
                     else:
                         hap2.write(line)

--- a/harpy/snakefiles/simulate_variants.smk
+++ b/harpy/snakefiles/simulate_variants.smk
@@ -81,7 +81,7 @@ rule simulate_haploid:
     shell:
         "perl {params.simuG} -refseq {input.geno} -prefix {params.prefix} {params.parameters} > {log}"
 
-rule heterozygous_variants:
+rule diploid_variants:
     input:
         f"{outdir}/{outprefix}.vcf"
     output:


### PR DESCRIPTION
This PR accomplishes a few things:
1. creates rules in the corresponding simulate variants workflows to create the diploid genome when specifying a heterozygosity value.
2. adds a new `--only-vcf` option to the harpy simulate CLI to have the same behavior as before, where heterozygote VCFs were created without simulating those variants again
3. The rules were renamed to be clearer and more explicit
4. The rule that creates diploid VCFs has the open() calls all on a single block so their closing is automatically enforced
5. The randomseed, if set, now also applies to the diploid random seed.
6. Better and more explicit `harpy simulate` docstrings so it's easier to understand when you're creating a diploid. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `--only-vcf` option for various simulation commands, allowing users to generate only VCF files when heterozygosity is set.
	- Added a new rule for simulating diploid variants, enhancing the simulation capabilities.

- **Documentation**
	- Updated help documentation to reflect new options and clarify existing ones.

- **Bug Fixes**
	- Improved handling of output paths and file extensions for genetic variant simulations.
	- Enhanced configurability and organization of the variant simulation process.

- **Chores**
	- Updated GitHub Actions workflow for better concurrency control and cache management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->