### PR TITLE
add quast reports to assembly

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -1,6 +1,7 @@
 common: &common
   - 'harpy/_launch.py'
   - 'harpy/_misc.py'
+  - 'harpy/_cli_types.py'
   - 'harpy/_parsers.py'
   - 'harpy/_printing.py'
   - 'harpy/_validations.py'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -196,7 +196,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -238,7 +238,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -278,7 +278,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -315,7 +315,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -391,7 +391,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -429,7 +429,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -470,7 +470,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -511,7 +511,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -553,7 +553,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -601,7 +601,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -644,7 +644,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -696,7 +696,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -754,7 +754,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -792,7 +792,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -836,7 +836,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        uses: jlumbroso/free-disk-space@main
       - name: harpy stitchparams
         shell: micromamba-shell {0}
         run: harpy stitchparams -o params.file

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,7 +141,24 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        run: |
+          rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+          sudo rm -rf \
+            /opt/ghc
+            /opt/google/chrome \
+            /opt/microsoft/msedge \
+            /opt/microsoft/powershell \
+            /opt/pipx \
+            /usr/lib/mono \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/lib/node_modules \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/swift
+            /usr/share/dotnet
+            /usr/local/share/boost
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:
@@ -149,7 +166,7 @@ jobs:
           path: .snakemake/singularity
       - name: harpy demultiplex
         shell: micromamba-shell {0}
-        run: harpy demultiplex gen1 --quiet --conda --schema test/demux/samples.schema test/demux/Undetermined_S0_L004_R* test/demux/Undetermined_S0_L004_I*
+        run: harpy demultiplex gen1 --quiet --schema test/demux/samples.schema test/demux/Undetermined_S0_L004_R* test/demux/Undetermined_S0_L004_I*
 
   preflight:
     needs: [changes, pkgbuild]
@@ -336,7 +353,24 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+        run: |
+          rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
+          sudo rm -rf \
+            /opt/ghc
+            /opt/google/chrome \
+            /opt/microsoft/msedge \
+            /opt/microsoft/powershell \
+            /opt/pipx \
+            /usr/lib/mono \
+            /usr/local/julia* \
+            /usr/local/lib/android \
+            /usr/local/lib/node_modules \
+            /usr/local/share/chromium \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/swift
+            /usr/share/dotnet
+            /usr/local/share/boost
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,24 +141,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: |
-          rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
-          sudo rm -rf \
-            /opt/ghc
-            /opt/google/chrome \
-            /opt/microsoft/msedge \
-            /opt/microsoft/powershell \
-            /opt/pipx \
-            /usr/lib/mono \
-            /usr/local/julia* \
-            /usr/local/lib/android \
-            /usr/local/lib/node_modules \
-            /usr/local/share/chromium \
-            /usr/local/share/powershell \
-            /usr/share/dotnet \
-            /usr/share/swift
-            /usr/share/dotnet
-            /usr/local/share/boost
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -353,24 +353,7 @@ jobs:
           pip install dist/*.whl
           resources/buildforCI.sh
       - name: Clear Space
-        run: |
-          rm -rf /opt/hostedtoolcache && mkdir -p .snakemake/singularity
-          sudo rm -rf \
-            /opt/ghc
-            /opt/google/chrome \
-            /opt/microsoft/msedge \
-            /opt/microsoft/powershell \
-            /opt/pipx \
-            /usr/lib/mono \
-            /usr/local/julia* \
-            /usr/local/lib/android \
-            /usr/local/lib/node_modules \
-            /usr/local/share/chromium \
-            /usr/local/share/powershell \
-            /usr/share/dotnet \
-            /usr/share/swift
-            /usr/share/dotnet
-            /usr/local/share/boost
+        uses: jlumbroso/free-disk-space@main
       - name: Download Singularity Artifact
         uses: actions/download-artifact@v4
         with:

--- a/harpy/_cli_types.py
+++ b/harpy/_cli_types.py
@@ -1,0 +1,66 @@
+"""Module with helper function to set up Harpy workflows"""
+
+import os
+import click
+
+class IntList(click.ParamType):
+    """A class for a click type which accepts an arbitrary number of integers, separated by a comma."""
+    name = "int_list"
+    def __init__(self, max_entries):
+        super().__init__()
+        self.max_entries = max_entries
+
+    def convert(self, value, param, ctx):
+        try:
+            parts = [i.strip() for i in value.split(',')]
+            if len(parts) != self.max_entries:
+                raise ValueError
+            for i in parts:
+                try:
+                    int(i)
+                except:
+                    raise ValueError
+            return [int(i) for i in parts]
+        except ValueError:
+            self.fail(f"{value} is not a valid list of integers. The value should be {self.max_entries} integers separated by a comma.", param, ctx)
+
+class KParam(click.ParamType):
+    """A class for a click type which accepts any number of odd integers separated by a comma, or the word auto."""
+    name = "k_param"
+    def convert(self, value, param, ctx):
+        try:
+            if value == "auto":
+                return value
+            parts = [i.strip() for i in value.split(',')]
+            for i in parts:
+                if int(i) % 2 == 0 or int(i) > 128:
+                    raise ValueError
+            return [int(i) for i in parts]
+        except ValueError:
+            self.fail(f"{value} is not 'auto' or odd integers <128 separated by a comma.", param, ctx)
+
+class ContigList(click.ParamType):
+    """A class for a click type which accepts a file of contigs or a list of contigs separated by a comma."""
+    name = "contig_list"
+    def convert(self, value, param, ctx):
+        # check if it's a file
+        if os.path.exists(value):
+            if not os.path.isfile(value):
+                self.fail(f"{value} is not a file.", param, ctx)
+            with open(value, "r") as cont_in:
+                return [i.strip() for i in cont_in.readlines()]
+        else:
+            return [i.strip() for i in value.split(',')]
+
+class ContigList(click.ParamType):
+    """A class for a click type which accepts a file of contigs or a list of contigs separated by a comma."""
+    name = "contig_list"
+    def convert(self, value, param, ctx):
+        # check if it's a file
+        if os.path.exists(value):
+            if not os.path.isfile(value):
+                self.fail(f"{value} is not a file.", param, ctx)
+            with open(value, "r") as cont_in:
+                return [i.strip() for i in cont_in.readlines()]
+        else:
+            return [i.strip() for i in value.split(',')]

--- a/harpy/_cli_types.py
+++ b/harpy/_cli_types.py
@@ -52,15 +52,3 @@ class ContigList(click.ParamType):
         else:
             return [i.strip() for i in value.split(',')]
 
-class ContigList(click.ParamType):
-    """A class for a click type which accepts a file of contigs or a list of contigs separated by a comma."""
-    name = "contig_list"
-    def convert(self, value, param, ctx):
-        # check if it's a file
-        if os.path.exists(value):
-            if not os.path.isfile(value):
-                self.fail(f"{value} is not a file.", param, ctx)
-            with open(value, "r") as cont_in:
-                return [i.strip() for i in cont_in.readlines()]
-        else:
-            return [i.strip() for i in value.split(',')]

--- a/harpy/_conda.py
+++ b/harpy/_conda.py
@@ -23,6 +23,7 @@ def create_conda_recipes():
             "bioconda::cloudspades",
             "bioconda::links",
             "bioconda::quast",
+            "bioconda::busco",
             "bioconda::samtools",
             "bioconda::tigmint"
         ],

--- a/harpy/_conda.py
+++ b/harpy/_conda.py
@@ -22,6 +22,7 @@ def create_conda_recipes():
             "bioconda::bwa",
             "bioconda::cloudspades",
             "bioconda::links",
+            "bioconda::quast",
             "bioconda::samtools",
             "bioconda::tigmint"
         ],

--- a/harpy/_misc.py
+++ b/harpy/_misc.py
@@ -8,7 +8,6 @@ import shutil
 from datetime import datetime
 from pathlib import Path
 from importlib_resources import files
-import click
 from rich.progress import Progress, BarColumn, TextColumn, TimeElapsedColumn, SpinnerColumn
 import harpy.scripts
 import harpy.reports
@@ -100,52 +99,3 @@ def gzip_file(infile):
         with open(infile, 'rb') as f_in, gzip.open(infile + '.gz', 'wb', 6) as f_out:
             shutil.copyfileobj(f_in, f_out)
         os.remove(infile)
-
-class IntList(click.ParamType):
-    """A class for a click type which accepts an arbitrary number of integers, separated by a comma."""
-    name = "int_list"
-    def __init__(self, max_entries):
-        super().__init__()
-        self.max_entries = max_entries
-
-    def convert(self, value, param, ctx):
-        try:
-            parts = [i.strip() for i in value.split(',')]
-            if len(parts) != self.max_entries:
-                raise ValueError
-            for i in parts:
-                try:
-                    int(i)
-                except:
-                    raise ValueError
-            return [int(i) for i in parts]
-        except ValueError:
-            self.fail(f"{value} is not a valid list of integers. The value should be {self.max_entries} integers separated by a comma.", param, ctx)
-
-class KParam(click.ParamType):
-    """A class for a click type which accepts any number of odd integers separated by a comma, or the word auto."""
-    name = "k_param"
-    def convert(self, value, param, ctx):
-        try:
-            if value == "auto":
-                return value
-            parts = [i.strip() for i in value.split(',')]
-            for i in parts:
-                if int(i) % 2 == 0 or int(i) > 128:
-                    raise ValueError
-            return [int(i) for i in parts]
-        except ValueError:
-            self.fail(f"{value} is not 'auto' or odd integers <128 separated by a comma.", param, ctx)
-
-class ContigList(click.ParamType):
-    """A class for a click type which accepts a file of contigs or a list of contigs separated by a comma."""
-    name = "contig_list"
-    def convert(self, value, param, ctx):
-        # check if it's a file
-        if os.path.exists(value):
-            if not os.path.isfile(value):
-                self.fail(f"{value} is not a file.", param, ctx)
-            with open(value, "r") as cont_in:
-                return [i.strip() for i in cont_in.readlines()]
-        else:
-            return [i.strip() for i in value.split(',')]

--- a/harpy/align.py
+++ b/harpy/align.py
@@ -9,7 +9,8 @@ from rich import box
 from rich.table import Table
 import rich_click as click
 from ._conda import create_conda_recipes
-from ._misc import fetch_report, fetch_rule, snakemake_log, ContigList
+from ._misc import fetch_report, fetch_rule, snakemake_log
+from ._cli_types import  ContigList
 from ._launch import launch_snakemake
 from ._parsers import parse_fastq_inputs
 from ._printing import print_error, print_solution, print_notice

--- a/harpy/assembly.py
+++ b/harpy/assembly.py
@@ -8,7 +8,8 @@ from rich.table import Table
 import rich_click as click
 from ._conda import create_conda_recipes
 from ._launch import launch_snakemake
-from ._misc import fetch_rule, snakemake_log, KParam
+from ._misc import fetch_rule, snakemake_log
+from ._cli_types import KParam
 from ._validations import validate_fastq_bx
 
 docstring = {

--- a/harpy/assembly.py
+++ b/harpy/assembly.py
@@ -22,15 +22,15 @@ docstring = {
             "options": ["--arcs-extra", "--contig-length", "--links", "--min-aligned", "--min-quality", "--mismatch", "--molecule-distance", "--molecule-length", "--seq-identity", "--span"],            
         },
         {
-            "name": "Workflow Controls",
-            "options": ["--conda", "--hpc", "--output-dir", "--quiet", "--snakemake", "--threads", "--help"],
+            "name": "Other Options",
+            "options": ["--busco-organism", "--conda", "--hpc", "--output-dir", "--quiet", "--skip-reports", "--snakemake", "--threads", "--help"],
         },
     ]
 }
 
 @click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/assembly")
 # SPADES
-@click.option('-b', '--bx-tag', type = click.Choice(['BX', 'BC'], case_sensitive=False), default = "BX", show_default=True, help = "The header tag with the barcode (`BX` or `BC`)")
+@click.option('-b', '--bx-tag', type = click.Choice(['BX', 'BC'], case_sensitive=False), default = "BX", show_default=True, help = "The header tag with the barcode [`BX`,`BC`]")
 @click.option('-k', '--kmer-length', type = KParam(), show_default = True, default = "auto", help = 'K values to use for assembly (`odd` and `<128`)')
 @click.option('-r', '--max-memory',  type = click.IntRange(min = 1000, max_open = True), show_default = True, default = 10000, help = 'Maximum memory for spades to use, in megabytes')
 @click.option('-x', '--extra-params', type = str, help = 'Additional spades parameters, in quotes')
@@ -45,17 +45,19 @@ docstring = {
 @click.option("-l", "--molecule-length", type = int, default = 2000, show_default = True, help = "Minimum molecule length (bp)")
 @click.option("-i", "--seq-identity", type = click.IntRange(0,100), default = 98, show_default = True, help = "Minimum sequence identity") 
 @click.option("-s", "--span", type = int, default = 20, show_default = True, help = "Minimum number of spanning molecules to be considered assembled")
-# Common Workflow
+# Other Options
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Assembly", show_default=True,  help = 'Output directory name')
 @click.option('-t', '--threads', default = 4, show_default = True, type = click.IntRange(min = 1, max_open = True), help = 'Number of threads to use')
+@click.option('-u', '--busco-organism', type = click.Choice(['prokaryote', 'eukaryote', 'fungus'], case_sensitive=False), default = "eukaryote", show_default=True, help = "Organism type for BUSCO analysis [`eukaryote`,`prokaryote`,`fungus`]")
 @click.option('--conda',  is_flag = True, default = False, help = 'Use conda/mamba instead of a container')
 @click.option('--hpc',  type = click.Path(exists = True, file_okay = False, readable=True), help = 'Directory with HPC submission `config.yaml` file')
 @click.option('--quiet',  is_flag = True, show_default = True, default = False, help = 'Don\'t show output text while running')
 @click.option('--setup-only',  is_flag = True, hidden = True, default = False, help = 'Setup the workflow and exit')
+@click.option('--skip-reports',  is_flag = True, show_default = True, default = False, help = 'Don\'t generate HTML reports')
 @click.option('--snakemake',  type = str, help = 'Additional Snakemake parameters, in quotes')
 @click.argument('fastq_r1', required=True, type=click.Path(exists=True, readable=True), nargs=1)
 @click.argument('fastq_r2', required=True, type=click.Path(exists=True, readable=True), nargs=1)
-def assembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, output_dir, extra_params,arcs_extra,contig_length,links,min_quality,min_aligned,mismatch,molecule_distance,molecule_length,seq_identity,span,conda, threads, snakemake, quiet, hpc, setup_only):
+def assembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, output_dir, extra_params,arcs_extra,contig_length,links,min_quality,min_aligned,mismatch,molecule_distance,molecule_length,seq_identity,span, busco_organism, conda, threads, snakemake, quiet, hpc, setup_only, skip_reports):
     """
     Create an assembly from linked-reads
 
@@ -107,6 +109,10 @@ def assembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, output_dir, ex
             "minimum_links" : links
         },
         "workflow_call" : command.rstrip(),
+        "reports" : {
+            "skip": skip_reports,
+            "busco_organism": busco_organism
+        },
         "inputs": {
             "fastq_r1" : fastq_r1,
             "fastq_r2" : fastq_r2

--- a/harpy/assembly.py
+++ b/harpy/assembly.py
@@ -23,7 +23,7 @@ docstring = {
         },
         {
             "name": "Other Options",
-            "options": ["--busco-organism", "--conda", "--hpc", "--output-dir", "--quiet", "--skip-reports", "--snakemake", "--threads", "--help"],
+            "options": ["--conda", "--hpc", "--organism-type", "--output-dir", "--quiet", "--skip-reports", "--snakemake", "--threads", "--help"],
         },
     ]
 }
@@ -48,7 +48,7 @@ docstring = {
 # Other Options
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Assembly", show_default=True,  help = 'Output directory name')
 @click.option('-t', '--threads', default = 4, show_default = True, type = click.IntRange(min = 1, max_open = True), help = 'Number of threads to use')
-@click.option('-u', '--busco-organism', type = click.Choice(['prokaryote', 'eukaryote', 'fungus'], case_sensitive=False), default = "eukaryote", show_default=True, help = "Organism type for BUSCO analysis [`eukaryote`,`prokaryote`,`fungus`]")
+@click.option('-u', '--organism-type', type = click.Choice(['prokaryote', 'eukaryote', 'fungus'], case_sensitive=False), default = "eukaryote", show_default=True, help = "Organism type for BUSCO/RNA analysis [`eukaryote`,`prokaryote`,`fungus`]")
 @click.option('--conda',  is_flag = True, default = False, help = 'Use conda/mamba instead of a container')
 @click.option('--hpc',  type = click.Path(exists = True, file_okay = False, readable=True), help = 'Directory with HPC submission `config.yaml` file')
 @click.option('--quiet',  is_flag = True, show_default = True, default = False, help = 'Don\'t show output text while running')
@@ -57,7 +57,7 @@ docstring = {
 @click.option('--snakemake',  type = str, help = 'Additional Snakemake parameters, in quotes')
 @click.argument('fastq_r1', required=True, type=click.Path(exists=True, readable=True), nargs=1)
 @click.argument('fastq_r2', required=True, type=click.Path(exists=True, readable=True), nargs=1)
-def assembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, output_dir, extra_params,arcs_extra,contig_length,links,min_quality,min_aligned,mismatch,molecule_distance,molecule_length,seq_identity,span, busco_organism, conda, threads, snakemake, quiet, hpc, setup_only, skip_reports):
+def assembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, output_dir, extra_params,arcs_extra,contig_length,links,min_quality,min_aligned,mismatch,molecule_distance,molecule_length,seq_identity,span, organism_type, conda, threads, snakemake, quiet, hpc, setup_only, skip_reports):
     """
     Create an assembly from linked-reads
 
@@ -111,7 +111,7 @@ def assembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, output_dir, ex
         "workflow_call" : command.rstrip(),
         "reports" : {
             "skip": skip_reports,
-            "busco_organism": busco_organism
+            "organism_type": organism_type
         },
         "inputs": {
             "fastq_r1" : fastq_r1,

--- a/harpy/assembly.py
+++ b/harpy/assembly.py
@@ -15,15 +15,15 @@ docstring = {
     "harpy assembly": [
         {
             "name": "Assembly Parameters",
-            "options": ["--bx-tag", "--extra-params", "--kmer-length", "--max-memory"],
+            "options": ["--bx-tag", "--extra-params", "--kmer-length", "--max-memory", "--organism-type"],
         },
         {
-            "name": "Scaffolding Parameters (ignored for metassembly)",
+            "name": "Scaffolding Parameters",
             "options": ["--arcs-extra", "--contig-length", "--links", "--min-aligned", "--min-quality", "--mismatch", "--molecule-distance", "--molecule-length", "--seq-identity", "--span"],            
         },
         {
             "name": "Other Options",
-            "options": ["--conda", "--hpc", "--organism-type", "--output-dir", "--quiet", "--skip-reports", "--snakemake", "--threads", "--help"],
+            "options": ["--conda", "--hpc", "--output-dir", "--quiet", "--skip-reports", "--snakemake", "--threads", "--help"],
         },
     ]
 }
@@ -48,7 +48,7 @@ docstring = {
 # Other Options
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Assembly", show_default=True,  help = 'Output directory name')
 @click.option('-t', '--threads', default = 4, show_default = True, type = click.IntRange(min = 1, max_open = True), help = 'Number of threads to use')
-@click.option('-u', '--organism-type', type = click.Choice(['prokaryote', 'eukaryote', 'fungus'], case_sensitive=False), default = "eukaryote", show_default=True, help = "Organism type for BUSCO/RNA analysis [`eukaryote`,`prokaryote`,`fungus`]")
+@click.option('-u', '--organism-type', type = click.Choice(['prokaryote', 'eukaryote', 'fungus'], case_sensitive=False), default = "eukaryote", show_default=True, help = "Organism type for assembly report [`eukaryote`,`prokaryote`,`fungus`]")
 @click.option('--conda',  is_flag = True, default = False, help = 'Use conda/mamba instead of a container')
 @click.option('--hpc',  type = click.Path(exists = True, file_okay = False, readable=True), help = 'Directory with HPC submission `config.yaml` file')
 @click.option('--quiet',  is_flag = True, show_default = True, default = False, help = 'Don\'t show output text while running')

--- a/harpy/metassembly.py
+++ b/harpy/metassembly.py
@@ -19,7 +19,7 @@ docstring = {
         },
         {
             "name": "Workflow Controls",
-            "options": ["--conda", "--hpc", "--output-dir", "--quiet", "--skip-reports", "--snakemake", "--threads", "--help"],
+            "options": ["--conda", "--hpc", "--organism", "--output-dir", "--quiet", "--skip-reports", "--snakemake", "--threads", "--help"],
         },
     ]
 }
@@ -34,6 +34,7 @@ docstring = {
 # Common Workflow
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Metassembly", show_default=True,  help = 'Output directory name')
 @click.option('-t', '--threads', default = 4, show_default = True, type = click.IntRange(min = 1, max_open = True), help = 'Number of threads to use')
+@click.option('-u', '--organism-type', type = click.Choice(['prokaryote', 'eukaryote', 'fungus'], case_sensitive=False), default = "eukaryote", show_default=True, help = "Organism type for BUSCO/RNA analysis [`eukaryote`,`prokaryote`,`fungus`]")
 @click.option('--conda',  is_flag = True, default = False, help = 'Use conda/mamba instead of a container')
 @click.option('--hpc',  type = click.Path(exists = True, file_okay = False, readable=True), help = 'Directory with HPC submission `config.yaml` file')
 @click.option('--quiet',  is_flag = True, show_default = True, default = False, help = 'Don\'t show output text while running')
@@ -42,7 +43,7 @@ docstring = {
 @click.option('--snakemake',  type = str, help = 'Additional Snakemake parameters, in quotes')
 @click.argument('fastq_r1', required=True, type=click.Path(exists=True, readable=True), nargs=1)
 @click.argument('fastq_r2', required=True, type=click.Path(exists=True, readable=True), nargs=1)
-def metassembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, ignore_bx, output_dir, extra_params, conda, threads, snakemake, quiet, hpc, setup_only, skip_reports):
+def metassembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, ignore_bx, output_dir, extra_params, conda, threads, snakemake, quiet, hpc, organism_type, setup_only, skip_reports):
     """
     Create a metassembly from linked-reads
 
@@ -78,7 +79,10 @@ def metassembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, ignore_bx, 
             **({'extra' : extra_params} if extra_params else {})
         },
         "workflow_call" : command.rstrip(),
-        "reports" : {"skip": skip_reports},
+        "reports" : {
+            "skip": skip_reports,
+            "organism_type": organism_type
+        },
         "inputs": {
             "fastq_r1" : fastq_r1,
             "fastq_r2" : fastq_r2

--- a/harpy/metassembly.py
+++ b/harpy/metassembly.py
@@ -8,7 +8,8 @@ from rich.table import Table
 import rich_click as click
 from ._conda import create_conda_recipes
 from ._launch import launch_snakemake
-from ._misc import fetch_rule, snakemake_log, KParam
+from ._misc import fetch_rule, snakemake_log
+from ._cli_types import KParam
 from ._validations import validate_fastq_bx
 
 docstring = {

--- a/harpy/metassembly.py
+++ b/harpy/metassembly.py
@@ -19,7 +19,7 @@ docstring = {
         },
         {
             "name": "Workflow Controls",
-            "options": ["--conda", "--hpc", "--output-dir", "--quiet", "--snakemake", "--threads", "--help"],
+            "options": ["--conda", "--hpc", "--output-dir", "--quiet", "--skip-reports", "--snakemake", "--threads", "--help"],
         },
     ]
 }
@@ -38,10 +38,11 @@ docstring = {
 @click.option('--hpc',  type = click.Path(exists = True, file_okay = False, readable=True), help = 'Directory with HPC submission `config.yaml` file')
 @click.option('--quiet',  is_flag = True, show_default = True, default = False, help = 'Don\'t show output text while running')
 @click.option('--setup-only',  is_flag = True, hidden = True, default = False, help = 'Setup the workflow and exit')
+@click.option('--skip-reports',  is_flag = True, show_default = True, default = False, help = 'Don\'t generate HTML reports')
 @click.option('--snakemake',  type = str, help = 'Additional Snakemake parameters, in quotes')
 @click.argument('fastq_r1', required=True, type=click.Path(exists=True, readable=True), nargs=1)
 @click.argument('fastq_r2', required=True, type=click.Path(exists=True, readable=True), nargs=1)
-def metassembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, ignore_bx, output_dir, extra_params, conda, threads, snakemake, quiet, hpc, setup_only):
+def metassembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, ignore_bx, output_dir, extra_params, conda, threads, snakemake, quiet, hpc, setup_only, skip_reports):
     """
     Create a metassembly from linked-reads
 
@@ -77,6 +78,7 @@ def metassembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, ignore_bx, 
             **({'extra' : extra_params} if extra_params else {})
         },
         "workflow_call" : command.rstrip(),
+        "reports" : {"skip": skip_reports},
         "inputs": {
             "fastq_r1" : fastq_r1,
             "fastq_r2" : fastq_r2

--- a/harpy/metassembly.py
+++ b/harpy/metassembly.py
@@ -32,7 +32,7 @@ docstring = {
 @click.option('--ignore-bx', is_flag = True, show_default = True, default = False, help = 'Ignore linked-read info for initial spades assembly')
 @click.option('-x', '--extra-params', type = str, help = 'Additional spades parameters, in quotes')
 # Common Workflow
-@click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Assembly", show_default=True,  help = 'Output directory name')
+@click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Metassembly", show_default=True,  help = 'Output directory name')
 @click.option('-t', '--threads', default = 4, show_default = True, type = click.IntRange(min = 1, max_open = True), help = 'Number of threads to use')
 @click.option('--conda',  is_flag = True, default = False, help = 'Use conda/mamba instead of a container')
 @click.option('--hpc',  type = click.Path(exists = True, file_okay = False, readable=True), help = 'Directory with HPC submission `config.yaml` file')

--- a/harpy/metassembly.py
+++ b/harpy/metassembly.py
@@ -15,16 +15,16 @@ docstring = {
     "harpy metassembly": [
         {
             "name": "Metassembly Parameters",
-            "options": ["--bx-tag", "--extra-params", "--ignore-bx","--kmer-length", "--max-memory", "--metassembly"],
+            "options": ["--bx-tag", "--extra-params", "--ignore-bx","--kmer-length", "--max-memory", "--metassembly", "--organism-type"],
         },
         {
             "name": "Workflow Controls",
-            "options": ["--conda", "--hpc", "--organism", "--output-dir", "--quiet", "--skip-reports", "--snakemake", "--threads", "--help"],
+            "options": ["--conda", "--hpc", "--output-dir", "--quiet", "--skip-reports", "--snakemake", "--threads", "--help"],
         },
     ]
 }
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/assembly")
+@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/metassembly")
 # SPADES
 @click.option('-b', '--bx-tag', type = click.Choice(['BX', 'BC'], case_sensitive=False), default = "BX", show_default=True, help = "The header tag with the barcode (`BX` or `BC`)")
 @click.option('-k', '--kmer-length', type = KParam(), show_default = True, default = "auto", help = 'K values to use for assembly (`odd` and `<128`)')
@@ -34,7 +34,7 @@ docstring = {
 # Common Workflow
 @click.option('-o', '--output-dir', type = click.Path(exists = False), default = "Metassembly", show_default=True,  help = 'Output directory name')
 @click.option('-t', '--threads', default = 4, show_default = True, type = click.IntRange(min = 1, max_open = True), help = 'Number of threads to use')
-@click.option('-u', '--organism-type', type = click.Choice(['prokaryote', 'eukaryote', 'fungus'], case_sensitive=False), default = "eukaryote", show_default=True, help = "Organism type for BUSCO/RNA analysis [`eukaryote`,`prokaryote`,`fungus`]")
+@click.option('-u', '--organism-type', type = click.Choice(['prokaryote', 'eukaryote', 'fungus'], case_sensitive=False), default = "eukaryote", show_default=True, help = "Organism type for assembly report [`eukaryote`,`prokaryote`,`fungus`]")
 @click.option('--conda',  is_flag = True, default = False, help = 'Use conda/mamba instead of a container')
 @click.option('--hpc',  type = click.Path(exists = True, file_okay = False, readable=True), help = 'Directory with HPC submission `config.yaml` file')
 @click.option('--quiet',  is_flag = True, show_default = True, default = False, help = 'Don\'t show output text while running')

--- a/harpy/phase.py
+++ b/harpy/phase.py
@@ -8,7 +8,8 @@ from rich.table import Table
 import rich_click as click
 from ._conda import create_conda_recipes
 from ._launch import launch_snakemake
-from ._misc import fetch_rule, fetch_report, snakemake_log, ContigList
+from ._misc import fetch_rule, fetch_report, snakemake_log
+from ._cli_types import ContigList
 from ._parsers import parse_alignment_inputs
 from ._validations import check_fasta, vcf_sample_match, validate_bam_RG, validate_input_by_ext, vcf_contig_match
 

--- a/harpy/qc.py
+++ b/harpy/qc.py
@@ -8,7 +8,8 @@ from rich.table import Table
 import rich_click as click
 from ._conda import create_conda_recipes
 from ._launch import launch_snakemake
-from ._misc import fetch_report, fetch_rule, snakemake_log, IntList
+from ._misc import fetch_report, fetch_rule, snakemake_log
+from ._cli_types import IntList
 from ._parsers import parse_fastq_inputs
 
 docstring = {

--- a/harpy/snakefiles/align_bwa.smk
+++ b/harpy/snakefiles/align_bwa.smk
@@ -95,13 +95,11 @@ rule align:
     log:
         outdir + "/logs/bwa/{sample}.bwa.log"
     params:
-        RG_tag = lambda wc: "\"@RG\\tID:" + wc.get("sample") + "\\tSM:" wc.get("sample") + "\"",
+        RG_tag = lambda wc: "\"@RG\\tID:" + wc.get("sample") + "\\tSM:" + wc.get("sample") + "\"",
         samps = lambda wc: d[wc.get("sample")],
         quality = config["alignment_quality"],
         unmapped = "" if keep_unmapped else "-F 4",
         extra = extra
-    benchmark:
-        ".Benchmark/Mapping/bwa/align.{sample}.txt"
     threads:
         max(5, workflow.cores - 1)
     conda:

--- a/harpy/snakefiles/align_bwa.smk
+++ b/harpy/snakefiles/align_bwa.smk
@@ -90,11 +90,12 @@ rule align:
         fastq      = get_fq,
         genome     = f"Genome/{bn}",
         genome_idx = multiext(f"Genome/{bn}", ".ann", ".bwt", ".pac", ".sa", ".amb")
-    output:  
+    output:
         temp(outdir + "/samples/{sample}/{sample}.bwa.sam")
     log:
         outdir + "/logs/bwa/{sample}.bwa.log"
-    params: 
+    params:
+        RG_tag = lambda wc: "\"@RG\\tID:" + wc.get("sample") + "\\tSM:" wc.get("sample") + "\"",
         samps = lambda wc: d[wc.get("sample")],
         quality = config["alignment_quality"],
         unmapped = "" if keep_unmapped else "-F 4",
@@ -107,7 +108,7 @@ rule align:
         f"{envdir}/align.yaml"
     shell:
         """
-        bwa mem -C -v 2 -t {threads} {params.extra} -R \"@RG\\tID:{wildcards.sample}\\tSM:{wildcards.sample}\" {input.genome} {input.fastq} 2> {log} |
+        bwa mem -C -v 2 -t {threads} {params.extra} -R {params.RG_tag} {input.genome} {input.fastq} 2> {log} |
             samtools view -h {params.unmapped} -q {params.quality} > {output} 
         """
 

--- a/harpy/snakefiles/align_ema.smk
+++ b/harpy/snakefiles/align_ema.smk
@@ -6,7 +6,6 @@ import logging
 
 onstart:
     logger.logger.addHandler(logging.FileHandler(config["snakemake_log"]))
-    os.makedirs(f"{outdir}/logs/ema_count/", exist_ok = True)
 onsuccess:
     os.remove(logger.logfile)
 onerror:
@@ -33,6 +32,7 @@ plot_contigs = config["reports"]["plot_contigs"]
 bn_r = r"([_\.][12]|[_\.][FR]|[_\.]R[12](?:\_00[0-9])*)?\.((fastq|fq)(\.gz)?)$"
 samplenames = {re.sub(bn_r, "", os.path.basename(i), flags = re.IGNORECASE) for i in fqlist}
 d = dict(zip(samplenames, samplenames))
+os.makedirs(f"{outdir}/logs/ema_count/", exist_ok = True)
 
 def get_fq(wildcards):
     """returns a list of fastq files for read 1 based on *wildcards.sample* e.g."""

--- a/harpy/snakefiles/align_ema.smk
+++ b/harpy/snakefiles/align_ema.smk
@@ -6,7 +6,7 @@ import logging
 
 onstart:
     logger.logger.addHandler(logging.FileHandler(config["snakemake_log"]))
-    os.path.makedirs(f"{outdir}/logs/ema_count/", exist_ok = True)
+    os.makedirs(f"{outdir}/logs/ema_count/", exist_ok = True)
 onsuccess:
     os.remove(logger.logfile)
 onerror:

--- a/harpy/snakefiles/align_ema.smk
+++ b/harpy/snakefiles/align_ema.smk
@@ -146,7 +146,7 @@ rule align_ema:
     resources:
         mem_mb = 500
     params:
-        RG_tag = lambda wc: "\"@RG\\tID:" + wc.get("sample") + "\\tSM:" wc.get("sample") + "\"",
+        RG_tag = lambda wc: "\"@RG\\tID:" + wc.get("sample") + "\\tSM:" + wc.get("sample") + "\"",
         bxtype = f"-p {platform}",
         tmpdir = lambda wc: outdir + "/." + d[wc.sample],
         quality = config["alignment_quality"],
@@ -176,16 +176,15 @@ rule align_bwa:
         outdir + "/logs/align/{sample}.bwa.align.log"
     params:
         quality = config["alignment_quality"],
-        unmapped = "" if keep_unmapped else "-F 4"
-    benchmark:
-        ".Benchmark/Mapping/ema/bwaAlign.{sample}.txt"
+        unmapped = "" if keep_unmapped else "-F 4",
+        RG_tag = lambda wc: "\"@RG\\tID:" + wc.get("sample") + "\\tSM:" + wc.get("sample") + "\""
     threads:
         10
     conda:
         f"{envdir}/align.yaml"
     shell:
         """
-        bwa mem -t {threads} -v2 -C -R \"@RG\\tID:{wildcards.sample}\\tSM:{wildcards.sample}\" {input.genome} {input.reads} 2> {log} |
+        bwa mem -t {threads} -v2 -C -R {params.RG_tag} {input.genome} {input.reads} 2> {log} |
             samtools view -h {params.unmapped} -q {params.quality} > {output}
         """
 

--- a/harpy/snakefiles/align_strobealign.smk
+++ b/harpy/snakefiles/align_strobealign.smk
@@ -91,8 +91,6 @@ rule align:
         unmapped_strobe = "" if keep_unmapped else "-U",
         unmapped = "" if keep_unmapped else "-F 4",
         extra = extra
-    benchmark:
-        ".Benchmark/Mapping/strobealign/align.{sample}.txt"
     threads:
         max(5, workflow.cores - 1)
     conda:

--- a/harpy/snakefiles/assembly.smk
+++ b/harpy/snakefiles/assembly.smk
@@ -134,7 +134,8 @@ rule quality_report:
 rule workflow_summary:
     default_target: True
     input:
-        f"{outdir}/scaffolds.fasta"
+        f"{outdir}/scaffolds.fasta",
+        f"{outdir}/reports/report.html"
     params:
         k_param = k_param,
         max_mem = max_mem // 1000,

--- a/harpy/snakefiles/assembly.smk
+++ b/harpy/snakefiles/assembly.smk
@@ -141,7 +141,7 @@ rule BUSCO_analysis:
     input:
         f"{outdir}/scaffolds.fasta"
     output:
-        f"{outdir}/busco/short_summary.specific.{lineagedb}_obd10.busco.txt"
+        f"{outdir}/busco/short_summary.specific.{lineagedb}_odb10.busco.txt"
     log:
         f"{outdir}/logs/busco.log"
     params:
@@ -155,12 +155,13 @@ rule BUSCO_analysis:
     conda:
         f"{envdir}/assembly.yaml"
     shell:
-        "busco -f -i {input} -c {threads} -m genome --out_path {params} > {log} 2>&1"
-#TODO CREATE TRY/CATCH THAT WRITES EMPTY BUSCO FILE
+        """
+        ( busco -f -i {input} -c {threads} -m genome --out_path {params} > {log} 2>&1 ) || touch {output}
+        """
 
 rule build_report:
     input:
-        f"{outdir}/busco/short_summary.specific.{lineagedb}_obd10.busco.txt",
+        f"{outdir}/busco/short_summary.specific.{lineagedb}_odb10.busco.txt",
         f"{outdir}/quast/report.tsv"
     output:
         f"{outdir}/reports/assembly.metrics.html"

--- a/harpy/snakefiles/assembly.smk
+++ b/harpy/snakefiles/assembly.smk
@@ -16,12 +16,12 @@ outdir = config["output_directory"]
 envdir = os.path.join(os.getcwd(), ".harpy_envs")
 skip_reports  = config["reports"]["skip"]
 organism = config["reports"]["organism_type"]
-if organism == "eukaryote":
-    lineagedb = "eukaryota"
-elif organism == "fungus":
-    lineagedb = "fungi"
-else:
-    lineagedb = "bacteria"
+lineage_map = {
+    "eukaryote": "eukaryota",
+    "fungus": "fungi",
+    "bacteria": "bacteria"
+}
+lineagedb = lineage_map.get(organism, "bacteria")
 # SPADES
 max_mem      = config["spades"]["max_memory"]
 k_param      = config["spades"]["k"]

--- a/harpy/snakefiles/assembly.smk
+++ b/harpy/snakefiles/assembly.smk
@@ -120,17 +120,15 @@ rule quality_report:
     log:
         f"{outdir}/logs/quast.log"
     params:
-        output_dir = f"{outdir}/reports",
-        busco_db = f"--{busco_organism}",
+        output_dir = f"-o {outdir}/reports",
+        busco_db = f"--{busco_organism}" if busco_organism != "prokaryote" else "",
         quast_params = "--labels cloudspades --conserved-genes-finding --no-sv" 
     threads:
         workflow.cores
     conda:
         f"{envdir}/assembly.yaml"
     shell:
-    """
-    quast.py --threads {threads} --pe12 {input.fastq} {params.quast_params} {params.busco_db} -o {params.output_dir} {input.assembly} 2> {log}
-    """
+        "quast.py --threads {threads} --pe12 {input.fastq} {params} {input.assembly} 2> {log}"
 
 rule workflow_summary:
     default_target: True

--- a/harpy/snakefiles/assembly.smk
+++ b/harpy/snakefiles/assembly.smk
@@ -14,7 +14,7 @@ FQ1 = config["inputs"]["fastq_r1"]
 FQ2 = config["inputs"]["fastq_r2"]
 outdir = config["output_directory"]
 envdir = os.path.join(os.getcwd(), ".harpy_envs")
-busco_organism = config["reports"]["busco_organism"]
+organism = config["reports"]["organism_type"]
 skip_reports  = config["reports"]["skip"]
 # SPADES
 max_mem      = config["spades"]["max_memory"]
@@ -118,11 +118,11 @@ rule quality_report:
     output:
         f"{outdir}/reports/report.html"
     log:
-        f"{outdir}/logs/quast.log"
+        f"{outdir}/reports/quast.log"
     params:
         output_dir = f"-o {outdir}/reports",
-        busco_db = f"--{busco_organism}" if busco_organism != "prokaryote" else "",
-        quast_params = "--labels cloudspades --conserved-genes-finding --no-sv" 
+        organism = f"--{organism}" if organism != "prokaryote" else "",
+        quast_params = "--labels harpy_cloudspades --conserved-genes-finding --rna-finding --no-sv" 
     threads:
         workflow.cores
     conda:

--- a/harpy/snakefiles/assembly.smk
+++ b/harpy/snakefiles/assembly.smk
@@ -148,7 +148,7 @@ rule BUSCO_analysis:
         output_folder = outdir,
         out_prefix = "-o busco",
         lineage = f"-l {lineagedb}",
-        download_path = f"--download_path {outdir}/busco"
+        download_path = f"--download_path {outdir}/busco",
         metaeuk = "--metaeuk" if organism == "eukaryote" else "" 
     threads:
         workflow.cores
@@ -160,7 +160,7 @@ rule BUSCO_analysis:
 
 rule build_report:
     input:
-        f"{outdir}/busco/short_summary.specific.{lineagedb}_odb10.busco.txt",
+        f"{outdir}/busco/short_summary.specific.{lineagedb}_obd10.busco.txt",
         f"{outdir}/quast/report.tsv"
     output:
         f"{outdir}/reports/assembly.metrics.html"

--- a/harpy/snakefiles/assembly.smk
+++ b/harpy/snakefiles/assembly.smk
@@ -15,6 +15,7 @@ FQ2 = config["inputs"]["fastq_r2"]
 outdir = config["output_directory"]
 envdir = os.path.join(os.getcwd(), ".harpy_envs")
 busco_organism = config["reports"]["busco_organism"]
+skip_reports  = config["reports"]["skip"]
 # SPADES
 max_mem      = config["spades"]["max_memory"]
 k_param      = config["spades"]["k"]
@@ -135,7 +136,7 @@ rule workflow_summary:
     default_target: True
     input:
         f"{outdir}/scaffolds.fasta",
-        f"{outdir}/reports/report.html"
+        f"{outdir}/reports/report.html" if not skip_reports else []
     params:
         k_param = k_param,
         max_mem = max_mem // 1000,

--- a/harpy/snakefiles/assembly.smk
+++ b/harpy/snakefiles/assembly.smk
@@ -14,8 +14,14 @@ FQ1 = config["inputs"]["fastq_r1"]
 FQ2 = config["inputs"]["fastq_r2"]
 outdir = config["output_directory"]
 envdir = os.path.join(os.getcwd(), ".harpy_envs")
-organism = config["reports"]["organism_type"]
 skip_reports  = config["reports"]["skip"]
+organism = config["reports"]["organism_type"]
+if organism == "eukaryote":
+    lineagedb = "eukaryota"
+elif organism == "fungus":
+    lineagedb = "fungi"
+else:
+    lineagedb = "bacteria"
 # SPADES
 max_mem      = config["spades"]["max_memory"]
 k_param      = config["spades"]["k"]
@@ -111,18 +117,19 @@ rule scaffolding:
         mv {params.workdir}/spades.tigmint*.scaffolds.fa {output}
         """
 
-rule quality_report:
+rule QUAST_assessment:
     input:
         assembly = f"{outdir}/scaffolds.fasta",
         fastq = f"{outdir}/scaffold/interleaved.fq.gz"
     output:
-        f"{outdir}/reports/report.html"
+        f"{outdir}/quast/report.tsv"
     log:
-        f"{outdir}/reports/quast.log"
+        f"{outdir}/quast/quast.log"
     params:
-        output_dir = f"-o {outdir}/reports",
+        output_dir = f"-o {outdir}/quast",
         organism = f"--{organism}" if organism != "prokaryote" else "",
-        quast_params = "--labels harpy_cloudspades --conserved-genes-finding --rna-finding --no-sv" 
+        quast_params = "--labels harpy_cloudspades --rna-finding",
+        skip_things = "--no-sv" 
     threads:
         workflow.cores
     conda:
@@ -130,11 +137,46 @@ rule quality_report:
     shell:
         "quast.py --threads {threads} --pe12 {input.fastq} {params} {input.assembly} 2> {log}"
 
+rule BUSCO_analysis:
+    input:
+        f"{outdir}/scaffolds.fasta"
+    output:
+        f"{outdir}/busco/short_summary.specific.{lineagedb}_obd10.busco.txt"
+    log:
+        f"{outdir}/logs/busco.log"
+    params:
+        output_folder = outdir,
+        out_prefix = "-o busco",
+        lineage = f"-l {lineagedb}",
+        download_path = f"--download_path {outdir}/busco"
+        metaeuk = "--metaeuk" if organism == "eukaryote" else "" 
+    threads:
+        workflow.cores
+    conda:
+        f"{envdir}/assembly.yaml"
+    shell:
+        "busco -f -i {input} -c {threads} -m genome --out_path {params} > {log} 2>&1"
+#TODO CREATE TRY/CATCH THAT WRITES EMPTY BUSCO FILE
+
+rule build_report:
+    input:
+        f"{outdir}/busco/short_summary.specific.{lineagedb}_odb10.busco.txt",
+        f"{outdir}/quast/report.tsv"
+    output:
+        f"{outdir}/reports/assembly.metrics.html"
+    params:
+        options = "--no-version-check --force --quiet --no-data-dir",
+        title = "--title \"Assembly Metrics\""
+    conda:
+        f"{envdir}/qc.yaml"
+    shell:
+        "multiqc {input} {params} --filename {output}"
+
 rule workflow_summary:
     default_target: True
     input:
         f"{outdir}/scaffolds.fasta",
-        f"{outdir}/reports/report.html" if not skip_reports else []
+        f"{outdir}/reports/assembly.metrics.html" if not skip_reports else [],
     params:
         k_param = k_param,
         max_mem = max_mem // 1000,

--- a/harpy/snakefiles/demultiplex_gen1.smk
+++ b/harpy/snakefiles/demultiplex_gen1.smk
@@ -105,6 +105,8 @@ rule assess_quality:
         outdir + "/{sample}.R{FR}.fq.gz"
     output: 
         outdir + "/reports/data/{sample}.R{FR}.fastqc"
+    log:
+        outdir + "/logs/{sample}.R{FR}.qc.log"
     params:
         f"{outdir}/reports/data"
     threads:
@@ -113,7 +115,7 @@ rule assess_quality:
         f"{envdir}/qc.yaml"
     shell:
         """
-        ( falco --quiet --threads {threads} -skip-report -skip-summary -data-filename {output} {input} ) > /dev/null 2>&1 ||
+        ( falco --quiet --threads {threads} -skip-report -skip-summary -data-filename {output} {input} ) > {log} 2>&1 ||
 cat <<EOF > {output}
 ##Falco	1.2.4
 >>Basic Statistics	fail

--- a/harpy/snakefiles/demultiplex_gen1.smk
+++ b/harpy/snakefiles/demultiplex_gen1.smk
@@ -113,7 +113,7 @@ rule assess_quality:
         f"{envdir}/qc.yaml"
     shell:
         """
-        ( falco --quiet --threads {threads} -skip-report -skip-summary -data-filename {output} {input} ) 2>&1 > /dev/null ||
+        ( falco --quiet --threads {threads} -skip-report -skip-summary -data-filename {output} {input} ) > /dev/null 2>&1 ||
 cat <<EOF > {output}
 ##Falco	1.2.4
 >>Basic Statistics	fail

--- a/harpy/snakefiles/metassembly.smk
+++ b/harpy/snakefiles/metassembly.smk
@@ -278,7 +278,7 @@ rule BUSCO_analysis:
         """
         ( busco -f -i {input} -c {threads} -m genome {params} > {log} 2>&1 ) || touch {output}
         """
-#TODO CREATE TRY/CATCH THAT WRITES EMPTY BUSCO FILE
+
 rule build_report:
     input:
         f"{outdir}/busco/short_summary.specific.{lineagedb}_odb10.busco.txt",

--- a/harpy/snakefiles/metassembly.smk
+++ b/harpy/snakefiles/metassembly.smk
@@ -269,10 +269,10 @@ rule workflow_summary:
         bxappend += f"\tsed 's/{params.bx}:Z:[^[:space:]]*/&-1/g' FASTQ | bgzip > FASTQ_OUT"  
         summary.append(bxappend)
         if not ignore_bx:
-            spades = f"Reads were assembled using 'cloudspades':\n"
+            spades = "Reads were assembled using cloudspades:\n"
             spades += f"\tspades.py -t THREADS -m {max_mem} --gemcode1-1 FQ1 --gemcode1-2 FQ2 --meta -k {k_param} {params.extra}"
-        else:f
-            spades = f"Reads were assembled using 'spades':\n"
+        else:
+            spades = "Reads were assembled using spades:\n"
             spades += f"\tmetaspades.py -t THREADS -m {max_mem} -k {k_param} {extra} -1 FQ_1 -2 FQ2 -o {spadesdir}"
         summary.append(spades)
         align = "Original input FASTQ files were aligned to the metagenome using BWA:\n"

--- a/harpy/snakefiles/metassembly.smk
+++ b/harpy/snakefiles/metassembly.smk
@@ -22,12 +22,12 @@ extra = config["spades"].get("extra", "")
 spadesdir = f"{outdir}/{'cloudspades' if not ignore_bx else 'spades'}_assembly"
 skip_reports  = config["reports"]["skip"]
 organism = config["reports"]["organism_type"]
-if organism == "eukaryote":
-    lineagedb = "eukaryota"
-elif organism == "fungus":
-    lineagedb = "fungi"
-else:
-    lineagedb = "bacteria"
+lineage_map = {
+    "eukaryote": "eukaryota",
+    "fungus": "fungi",
+    "bacteria": "bacteria"
+}
+lineagedb = lineage_map.get(organism, "bacteria")
 
 rule sort_by_barcode:
     input:

--- a/harpy/snakefiles/metassembly.smk
+++ b/harpy/snakefiles/metassembly.smk
@@ -18,6 +18,7 @@ envdir = os.path.join(os.getcwd(), ".harpy_envs")
 max_mem = config["spades"]["max_memory"]
 k_param = config["spades"]["k"]
 ignore_bx = config["spades"]["ignore_barcodes"]
+skip_reports  = config["reports"]["skip"]
 extra = config["spades"].get("extra", "")
 cloudspades = not ignore_bx
 spadesdir = f"{outdir}/{'cloudspades' if not ignore_bx else 'spades'}_assembly"

--- a/harpy/snakefiles/metassembly.smk
+++ b/harpy/snakefiles/metassembly.smk
@@ -261,7 +261,7 @@ rule BUSCO_analysis:
     input:
         f"{outdir}/athena/athena.asm.fa"
     output:
-        f"{outdir}/busco/short_summary.specific.{lineagedb}_odb10.busco.txt",
+        f"{outdir}/busco/short_summary.specific.{lineagedb}_odb10.busco.txt"
     log:
         f"{outdir}/logs/busco.log"
     params:
@@ -275,7 +275,9 @@ rule BUSCO_analysis:
     conda:
         f"{envdir}/assembly.yaml"
     shell:
-        "busco -f -i {input} -c {threads} -m genome {params} > {log} 2>&1"
+        """
+        ( busco -f -i {input} -c {threads} -m genome {params} > {log} 2>&1 ) || touch {output}
+        """
 #TODO CREATE TRY/CATCH THAT WRITES EMPTY BUSCO FILE
 rule build_report:
     input:

--- a/harpy/snakefiles/metassembly.smk
+++ b/harpy/snakefiles/metassembly.smk
@@ -285,7 +285,7 @@ rule build_report:
         f"{outdir}/reports/assembly.metrics.html"
     params:
         options = "--no-version-check --force --quiet --no-data-dir",
-        title = "--title \"Assembly Metrics\""
+        title = "--title \"Metassembly Metrics\""
     conda:
         f"{envdir}/qc.yaml"
     shell:

--- a/harpy/snakefiles/sv_leviathan.smk
+++ b/harpy/snakefiles/sv_leviathan.smk
@@ -59,8 +59,6 @@ rule index_barcode:
         bai = get_align_index
     output:
         temp(outdir + "/lrezIndexed/{sample}.bci")
-    benchmark:
-        ".Benchmark/leviathan/{sample}.lrez"
     threads:
         max(10, workflow.cores)
     conda:
@@ -123,8 +121,6 @@ rule call_variants:
         workflow.cores - 1
     conda:
         f"{envdir}/variants.yaml"
-    benchmark:
-        ".Benchmark/leviathan/{sample}.variantcall"
     shell:
         "LEVIATHAN -b {input.bam} -i {input.bc_idx} {params} -g {input.genome} -o {output.vcf} -t {threads} --candidates {output.candidates} 2> {log.runlog}"
 

--- a/harpy/snakefiles/sv_leviathan_pop.smk
+++ b/harpy/snakefiles/sv_leviathan_pop.smk
@@ -106,8 +106,6 @@ rule index_barcode:
         bai = outdir + "/workflow/input/{population}.bam.bai"
     output:
         temp(outdir + "/lrez_index/{population}.bci")
-    benchmark:
-        ".Benchmark/leviathan-pop/{population}.lrez"
     threads:
         max(10, workflow.cores)
     conda:
@@ -170,8 +168,6 @@ rule call_variants:
         workflow.cores - 1
     conda:
         f"{envdir}/variants.yaml"
-    benchmark:
-        ".Benchmark/leviathan-pop/{population}.variantcall"
     shell:
         "LEVIATHAN -b {input.bam} -i {input.bc_idx} {params} -g {input.genome} -o {output.vcf} -t {threads} --candidates {output.candidates} 2> {log.runlog}"
 

--- a/harpy/sv.py
+++ b/harpy/sv.py
@@ -9,7 +9,8 @@ from rich.table import Table
 import rich_click as click
 from ._conda import create_conda_recipes
 from ._launch import launch_snakemake
-from ._misc import fetch_rule, fetch_report, snakemake_log, ContigList
+from ._misc import fetch_rule, fetch_report, snakemake_log
+from ._cli_types import  ContigList
 from ._parsers import parse_alignment_inputs
 from ._validations import check_fasta, check_phase_vcf
 from ._validations import validate_popfile, validate_popsamples, fasta_contig_match

--- a/resources/harpy.yaml
+++ b/resources/harpy.yaml
@@ -2,7 +2,6 @@ name: harpy
 channels:
   - conda-forge
   - bioconda
-  - sshockwave
 dependencies:
   - apptainer
   - bcftools =1.20
@@ -14,4 +13,3 @@ dependencies:
   - samtools =1.20
   - seqtk
   - tabix
-  - gocryptfs


### PR DESCRIPTION
This PR adds quast and busco to the assembly workflows, including options to skip reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `--organism-type` option for specifying organism type in assembly and metassembly processes.
	- Introduced `--skip-reports` option to suppress HTML report generation.
	- Integrated new rules for quality assessment: `QUAST_assessment`, `BUSCO_analysis`, and `build_report` in workflows.
	- Enhanced command-line interface with improved parameter handling for quality control processes.
	- Added new dependencies for assembly tasks: `bioconda::quast` and `bioconda::busco`.

- **Bug Fixes**
	- Improved logging mechanisms for better traceability in workflows.
	- Removed benchmark directives in several rules to streamline performance tracking.

- **Chores**
	- Removed unnecessary dependencies: `ssshockwave` and `gocryptfs` from the configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->