### PR TITLE
add compression for output fasta

### DIFF
--- a/harpy/snakefiles/simulate_variants.smk
+++ b/harpy/snakefiles/simulate_variants.smk
@@ -131,7 +131,7 @@ rule rename_diploid:
         fasta = f"{outdir}/haplotype_{{haplotype}}/{outprefix}.hap{{haplotype}}.simseq.genome.fa",
         mapfile = f"{outdir}/haplotype_{{haplotype}}/{outprefix}.hap{{haplotype}}.refseq2simseq.map.txt"
     output:
-        fasta = f"{outdir}/haplotype_{{haplotype}}/{outprefix}.hap{{haplotype}}.fasta",
+        fasta = f"{outdir}/haplotype_{{haplotype}}/{outprefix}.hap{{haplotype}}.fasta.gz",
         mapfile = f"{outdir}/haplotype_{{haplotype}}/{outprefix}.hap{{haplotype}}.{variant}.map"
     container:
         None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced workflow file management with temporary file handling.
	- Added file compression for genome sequence and map files using `bgzip`.

- **Improvements**
	- Updated output file formats to use compressed `.gz` extensions.
	- Simplified file renaming and compression processes in Snakemake rules.

- **Technical Updates**
	- Modified Snakemake rules to use `temp()` for intermediate files.
	- Updated input/output signatures across multiple workflow rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->