### PR TITLE
change cli to remove inputs as options

### DIFF
--- a/harpy/bin/inline_to_haplotag.py
+++ b/harpy/bin/inline_to_haplotag.py
@@ -15,8 +15,8 @@ parser = argparse.ArgumentParser(
     )
 parser.add_argument("-p", "--prefix", required = True, type = str, help = "Prefix for outfile files (e.g. <prefix>.R1.fq.gz)")
 parser.add_argument("-b", "--barcodes", required = True, type=str, help="Barcode conversion key file with format: ATCG<tab>ACBD")
-parser.add_argument("forward", required = True, type = str, help = "Forward reads of paired-end FASTQ file pair (gzipped)")
-parser.add_argument("reverse", required = True, type = str, help = "Reverse reads of paired-end FASTQ file pair (gzipped)")
+parser.add_argument("forward", type = str, help = "Forward reads of paired-end FASTQ file pair (gzipped)")
+parser.add_argument("reverse", type = str, help = "Reverse reads of paired-end FASTQ file pair (gzipped)")
 if len(sys.argv) == 1:
     parser.print_help(sys.stderr)
     sys.exit(1)

--- a/harpy/bin/inline_to_haplotag.py
+++ b/harpy/bin/inline_to_haplotag.py
@@ -10,13 +10,13 @@ from itertools import zip_longest
 parser = argparse.ArgumentParser(
     prog = 'inline_to_haplotag.py',
     description = 'Moves inline linked read barcodes to read headers (OX:Z) and converts them into haplotag ACBD format (BX:Z). Barcodes must all be the same length.',
-    usage = f"inline_to_haplotag.py -f <forward.fq.gz> -r <reverse.fq.gz> -b <barcodes.txt> -p <prefix>",
+    usage = f"inline_to_haplotag.py -b <barcodes.txt> -p <prefix> FORWARD.fq.gz REVERSE.fq.gz",
     exit_on_error = False
     )
-parser.add_argument("-f", "--forward", required = True, type = str, help = "Forward reads of paired-end FASTQ file pair (gzipped)")
-parser.add_argument("-r", "--reverse", required = True, type = str, help = "Reverse reads of paired-end FASTQ file pair (gzipped)")
 parser.add_argument("-p", "--prefix", required = True, type = str, help = "Prefix for outfile files (e.g. <prefix>.R1.fq.gz)")
-parser.add_argument("-b", "--barcodes", required = True, type=str, help="File listing the linked-read barcodes to convert to haplotag format, one barcode per line")
+parser.add_argument("-b", "--barcodes", required = True, type=str, help="Barcode conversion key file with format: ATCG<tab>ACBD")
+parser.add_argument("forward", required = True, type = str, help = "Forward reads of paired-end FASTQ file pair (gzipped)")
+parser.add_argument("reverse", required = True, type = str, help = "Reverse reads of paired-end FASTQ file pair (gzipped)")
 if len(sys.argv) == 1:
     parser.print_help(sys.stderr)
     sys.exit(1)
@@ -112,7 +112,6 @@ with opener(args.barcodes, mode) as bc_file:
             sys.exit(1)
         
         insert_key_value(bc_db, ATCG, ACBD)
-        #bc_dict[ATCG] = ACBD
         lengths.add(len(ATCG))
     if len(lengths) > 1:
         sys.stderr.write("Can only search sequences for barcodes of a single length, but multiple barcode legnths detected: " + ",".join([str(i) for i in lengths]))

--- a/harpy/snakefiles/simulate_linkedreads.smk
+++ b/harpy/snakefiles/simulate_linkedreads.smk
@@ -169,7 +169,7 @@ rule demultiplex_barcodes:
     container:
         None
     shell:
-        "inline_to_haplotag.py -f {input.fw} -r {input.rv} -b {input.barcodes} -p {params} 2> {log}"
+        "inline_to_haplotag.py -b {input.barcodes} -p {params} {input.fw} {input.rv} 2> {log}"
 
 rule workflow_summary:
     default_target: True

--- a/harpy/snakefiles/simulate_linkedreads.smk
+++ b/harpy/snakefiles/simulate_linkedreads.smk
@@ -202,7 +202,7 @@ rule workflow_summary:
         haplosim += f"\tHaploSim.pl -g genome1,genome2 -a dwgsimreads1,dwgsimreads2 -l {params.lrbc_len} -p {params.lrsproj_dir}/linked_molecules/lrsim -b BARCODES -i {params.lrsoutdist} -s {params.lrsdist_sd} -x {params.lrsn_pairs} -f {params.lrsmol_len} -t {params.lrsparts} -m {params.lrsmols_per} -z THREADS {params.lrsstatic}"
         summary.append(haplosim)
         bxconvert = "Inline barcodes were converted in haplotag BX:Z tags using:\n"
-        bxconvert += "\tinline_to_haplotag.py -f <forward.fq.gz> -r <reverse.fq.gz> -b <barcodes.txt> -p <prefix>"
+        bxconvert += "\tinline_to_haplotag.py -b <barcodes.txt> -p <prefix> forward.fq.gz reverse.fq.gz"
         summary.append(bxconvert)
         sm = "The Snakemake workflow was called via command line:\n"
         sm += f"\t{config['workflow_call']}"

--- a/harpy/snakefiles/simulate_variants.smk
+++ b/harpy/snakefiles/simulate_variants.smk
@@ -131,7 +131,7 @@ rule rename_diploid:
         fasta = f"{outdir}/haplotype_{{haplotype}}/{outprefix}.hap{{haplotype}}.simseq.genome.fa",
         mapfile = f"{outdir}/haplotype_{{haplotype}}/{outprefix}.hap{{haplotype}}.refseq2simseq.map.txt"
     output:
-        fasta = f"{outdir}/haplotype_{{haplotype}}/{outprefix}.hap{{haplotype}}.fasta",
+        fasta = f"{outdir}/haplotype_{{haplotype}}/{outprefix}.hap{{haplotype}}.fasta.gz",
         mapfile = f"{outdir}/haplotype_{{haplotype}}/{outprefix}.hap{{haplotype}}.{variant}.map"
     container:
         None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated command-line interface for the `inline_to_haplotag.py` script with simplified argument structure
	- Clarified barcode conversion key file format

- **Bug Fixes**
	- None reported

- **Refactor**
	- Modified Snakemake workflow rules to use temporary and compressed output files
	- Streamlined file handling in simulation workflows

- **Chores**
	- Updated input/output file paths in multiple Snakemake workflow files
	- Improved file management by using compressed FASTA files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->