### PR TITLE
tweaks to the alignstats reports and lumen theme

### DIFF
--- a/harpy/reports/_quarto.yml
+++ b/harpy/reports/_quarto.yml
@@ -1,16 +1,18 @@
 brand:
-  logo: 
-    medium: https://raw.githubusercontent.com/pdimens/harpy/docs/static/logo_report.png
+  logo:
+    medium: https://raw.githubusercontent.com/pdimens/harpy/docs/static/favicon_report.svg
 execute:
     echo: false
     warning: false
 embed-resources: true
-format: 
+format:
   dashboard:
-    theme: materia
+    theme: 
+      - lumen
+      - harpy.scss
     scrolling: true
     expandable: false
-    logo: https://raw.githubusercontent.com/pdimens/harpy/docs/static/logo_report.png
+    logo: https://raw.githubusercontent.com/pdimens/harpy/docs/static/favicon_report.svg
     nav-buttons:
       - icon: book-half
         href: https://pdimens.github.io/harpy
@@ -18,3 +20,7 @@ format:
         href: https://github.com/pdimens/harpy/issues/new/choose
       - icon: code-slash
         href: https://github.com/pdimens/harpy
+    include-in-header:
+      text: |
+        <link rel="shortcut icon" href="https://raw.githubusercontent.com/pdimens/harpy/docs/static/favicon_report.svg" />
+        <link rel="icon" type="image/x-icon" href="https://raw.githubusercontent.com/pdimens/harpy/docs/static/favicon_report.svg">

--- a/harpy/reports/align_bxstats.qmd
+++ b/harpy/reports/align_bxstats.qmd
@@ -84,7 +84,6 @@ process_input <- function(infile){
 infiles <- list.files(params$indir, "bxstats.gz", full.names = TRUE)
 aggregate_df <- Reduce(rbind, Map(process_input, infiles))
 aggregate_df[is.na(aggregate_df)] <- 0
-aggregate_df[is.nan(aggregate_df)] <- 0
 
 if(nrow(aggregate_df) == 0){
   print("All input files were empty")

--- a/harpy/reports/align_bxstats.qmd
+++ b/harpy/reports/align_bxstats.qmd
@@ -32,81 +32,59 @@ std_error <- function(x){
 process_input <- function(infile){
   samplename <- gsub(".bxstats.gz", "", basename(infile))
   tb <- read.table(infile, header = T, sep = "\t") %>% select(-4, -5)
-  if(nrow(tb) == 0){
-    return(
-      data.frame(
-        sample = samplename,
-        totalreads = 0,
-        totaluniquemol = 0,
-        singletons = 0,
-        nonsingletons = 0,
-        totaluniquebx = 0,
-        molecule2bxratio = 0,
-        totalvalidreads = 0,
-        totalinvalidreads = 0,
-        totalvalidpercent = 0,
-        averagereadspermol = 0,
-        sereadspermol = 0,
-        averagemolcov = 0,
-        semolcov = 0,
-        averagemolcovbp = 0,
-        semolcovbp = 0,
-        N50 = 0,
-        N75 = 0,
-        N90 = 0
-      )
-    )
-  } else {
-    tb$valid <- tb$molecule
-    tb[tb$valid != "invalidBX", "valid"] <- "validBX"
-    tb$valid <- gsub("BX", " BX", tb$valid)
-    # isolate non-singletons b/c molecules with 1 read pair aren't linked reads
-    multiplex_df <- filter(tb, valid == "valid BX", reads >= 2)
-    singletons <- sum(tb$reads < 2 & tb$valid == "valid BX")
-    tot_uniq_bx <- read.table(infile, header = F, sep = "\n", as.is = T, skip = nrow(tb) + 1, comment.char = "+")
-    tot_uniq_bx <- gsub("#total unique barcodes: ", "", tot_uniq_bx$V1[1]) |> as.integer()
-    tot_mol <- sum(tb$valid == "valid BX")
-    tot_valid_reads <- sum(tb[tb$valid == "valid BX", "reads"])
-    avg_reads_per_mol <- round(mean(multiplex_df$reads),1)
-    sem_reads_per_mol <- round(std_error(multiplex_df$reads), 2)
-    tot_invalid_reads <- sum(tb[tb$valid == "invalid BX", "reads"])
-    avg_mol_cov <- round(mean(multiplex_df$coverage_inserts), 2)
-    sem_mol_cov <- round(std_error(multiplex_df$coverage_inserts), 4)
-    avg_mol_cov_bp <- round(mean(multiplex_df$coverage_bp), 2)
-    sem_mol_cov_bp<- round(std_error(multiplex_df$coverage_bp), 4)
-    n50 <- NX(multiplex_df$length_inferred, 50)
-    n75 <- NX(multiplex_df$length_inferred, 75)
-    n90 <- NX(multiplex_df$length_inferred, 90)
-    return(
-      data.frame(
-        sample = samplename,
-        totalreads = tot_valid_reads + tot_invalid_reads,
-        totaluniquemol = tot_mol,
-        singletons = singletons,
-        nonsingletons = nrow(multiplex_df),
-        totaluniquebx = tot_uniq_bx,
-        molecule2bxratio = round(tot_mol / tot_uniq_bx,2),
-        totalvalidreads = tot_valid_reads,
-        totalinvalidreads = tot_invalid_reads,
-        totalvalidpercent = round(tot_valid_reads/(tot_valid_reads + tot_invalid_reads) * 100,2),
-        averagereadspermol = avg_reads_per_mol,
-        sereadspermol = sem_reads_per_mol,
-        averagemolcov = avg_mol_cov,
-        semolcov = sem_mol_cov,
-        averagemolcovbp = avg_mol_cov_bp,
-        semolcovbp = sem_mol_cov_bp,
-        N50 = n50,
-        N75 = n75,
-        N90 = n90
-      )
-    )
-  }
+  tb$valid <- tb$molecule
+  tb[tb$valid != "invalidBX", "valid"] <- "validBX"
+  tb$valid <- gsub("BX", " BX", tb$valid)
+  # isolate non-singletons b/c molecules with 1 read pair aren't linked reads
+  multiplex_df <- filter(tb, valid == "valid BX", reads >= 2)
+  singletons <- sum(tb$reads < 2 & tb$valid == "valid BX")
+  tot_uniq_bx <- read.table(infile, header = F, sep = "\n", as.is = T, skip = nrow(tb) + 1, comment.char = "+")
+  tot_uniq_bx <- gsub("#total unique barcodes: ", "", tot_uniq_bx$V1[1]) |> as.integer()
+  tot_mol <- sum(tb$valid == "valid BX")
+  tot_valid_reads <- sum(tb[tb$valid == "valid BX", "reads"])
+  avg_reads_per_mol <- round(mean(multiplex_df$reads),1)
+  sem_reads_per_mol <- round(std_error(multiplex_df$reads), 2)
+  tot_invalid_reads <- sum(tb[tb$valid == "invalid BX", "reads"])
+  avg_mol_cov <- round(mean(multiplex_df$coverage_inserts), 2)
+  sem_mol_cov <- round(std_error(multiplex_df$coverage_inserts), 4)
+  avg_mol_cov_bp <- round(mean(multiplex_df$coverage_bp), 2)
+  sem_mol_cov_bp<- round(std_error(multiplex_df$coverage_bp), 4)
+  n50 <- NX(multiplex_df$length_inferred, 50)
+  n75 <- NX(multiplex_df$length_inferred, 75)
+  n90 <- NX(multiplex_df$length_inferred, 90)
+  datarow <- data.frame(
+    sample = samplename,
+    totalreads = tot_valid_reads + tot_invalid_reads,
+    totaluniquemol = tot_mol,
+    singletons = singletons,
+    nonsingletons = nrow(multiplex_df),
+    totaluniquebx = tot_uniq_bx,
+    molecule2bxratio = round(tot_mol / tot_uniq_bx,2),
+    totalvalidreads = tot_valid_reads,
+    totalinvalidreads = tot_invalid_reads,
+    totalvalidpercent = round(tot_valid_reads/(tot_valid_reads + tot_invalid_reads) * 100,2),
+    averagereadspermol = avg_reads_per_mol,
+    sereadspermol = sem_reads_per_mol,
+    averagemolcov = avg_mol_cov,
+    semolcov = sem_mol_cov,
+    averagemolcovbp = avg_mol_cov_bp,
+    semolcovbp = sem_mol_cov_bp,
+    N50 = n50,
+    N75 = n75,
+    N90 = n90
+  )
+  #datarow[is.na(datarow)] <- 0
+  #datarow[is.nan(datarow)] <- 0
+  return(datarow)
 }
+
 ```
 
 ```{r setup_df}
 infiles <- list.files(params$indir, "bxstats.gz", full.names = TRUE)
 aggregate_df <- Reduce(rbind, Map(process_input, infiles))
+aggregate_df[is.na(aggregate_df)] <- 0
+aggregate_df[is.nan(aggregate_df)] <- 0
 
 if(nrow(aggregate_df) == 0){
   print("All input files were empty")

--- a/harpy/reports/align_stats.qmd
+++ b/harpy/reports/align_stats.qmd
@@ -26,9 +26,6 @@ using("dplyr","highcharter","DT","BioCircos")
 ```
 
 ```{r import_file, results = F}
-#infile <- "~/test.gz"
-#samplename <- "test sample"
-#sm_moldist <- 50000
 infile <- params$bxstats
 samplename <- params$sample
 sm_moldist <- params$mol_dist

--- a/harpy/reports/harpy.scss
+++ b/harpy/reports/harpy.scss
@@ -1,0 +1,17 @@
+/*-- scss:defaults --*/
+$navbar-bg:     #f4f4f4;
+$navbar-fg:     #3d3d3d;
+
+// Fonts
+
+$font-family-sans-serif:    Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif !default;
+$font-size-root:            1rem !default;
+$font-weight-base:          400 !default;
+
+/*-- scss:rules --*/
+// Variables
+
+$web-font-path: "https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" !default;
+@if $web-font-path {
+  @import url($web-font-path);
+}


### PR DESCRIPTION
- This PR fixes #201 by handling `NA` and `NaN` sample stats as `0`.
- It also restores the `lumen` theme to harpy reports, to mimic the cleaner style they were with flexdashboard

## TODO
There needs to be a followup PR where the `_quarto.yml` and `harpy.scss` files are pulled from github in the rules. This design would make the report styles consistent with the latest design, regardless of what harpy version you're on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated report branding with new SVG logos, dual-theme support, and refreshed header icons.
  - Enhanced visual styling with updated navigation colors and typography for a more modern look.

- **Refactor**
  - Streamlined data processing for statistical reports, ensuring consistent metric calculations even for empty inputs.
  - Refined aggregation logic for read counts and simplified parameter handling to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->