### PR TITLE
expand convert standardize

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -810,96 +810,96 @@ jobs:
           pip install --no-deps dist/*.whl
       - name: convert haplotag to stlfr
         shell: micromamba-shell {0}
-        run: harpy convert fastq --quiet 2 -o convert/stlfr haplotagging stlfr test/fastq/sample1.*gz
+        run: harpy convert fastq --quiet 2 -o convert/stlfr stlfr test/fastq/sample1.*gz
       - name: convert haplotag to tellseq
         shell: micromamba-shell {0}
-        run: harpy convert fastq --quiet 2 -o convert/tellseq haplotagging tellseq test/fastq/sample1.*gz
+        run: harpy convert fastq --quiet 2 -o convert/tellseq tellseq test/fastq/sample1.*gz
       - name: convert haplotag to 10x
         shell: micromamba-shell {0}
-        run: harpy convert fastq --quiet 2 -o convert/10x haplotagging 10x test/fastq/sample1.*gz
+        run: harpy convert fastq --quiet 2 -o convert/10x 10x test/fastq/sample1.*gz
       - name: convert stlfr to haplotag
         shell: micromamba-shell {0}
-        run: harpy convert fastq --quiet 2 -o convert_stlfr/haptag stlfr haplotagging convert/stlfr.*gz
+        run: harpy convert fastq --quiet 2 -o convert_stlfr/haptag haplotagging convert/stlfr.*gz
       - name: convert stlfr to tellseq
         shell: micromamba-shell {0}
-        run: harpy convert fastq --quiet 2 -o convert_stlfr/tellseq stlfr tellseq convert/stlfr.*gz
+        run: harpy convert fastq --quiet 2 -o convert_stlfr/tellseq tellseq convert/stlfr.*gz
       - name: convert stlfr to 10x
         shell: micromamba-shell {0}
-        run: harpy convert fastq --quiet 2 -o convert_stlfr/10x stlfr 10x convert/stlfr.*gz
+        run: harpy convert fastq --quiet 2 -o convert_stlfr/10x 10x convert/stlfr.*gz
       - name: convert stlfr to standard
         shell: micromamba-shell {0}
         run: |
-          harpy convert fastq --quiet 2 -o convert_stlfr/standard stlfr standard convert/stlfr.*gz
+          harpy convert fastq --quiet 2 -o convert_stlfr/standard standard convert/stlfr.*gz
           rm -rf convert_stlfr
       - name: convert tellseq to 10x
         shell: micromamba-shell {0}
-        run: harpy convert fastq --quiet 2 -o convert_tellseq/10x tellseq 10x convert/tellseq.*gz
+        run: harpy convert fastq --quiet 2 -o convert_tellseq/10x 10x convert/tellseq.*gz
       - name: convert tellseq to stlfr
         shell: micromamba-shell {0}
-        run: harpy convert fastq --quiet 2 -o convert_tellseq/stlfr tellseq stlfr convert/tellseq.*gz
+        run: harpy convert fastq --quiet 2 -o convert_tellseq/stlfr stlfr convert/tellseq.*gz
       - name: convert tellseq to haplotag
         shell: micromamba-shell {0}
-        run: harpy convert fastq --quiet 2 -o convert_tellseq/haptag tellseq haplotagging convert/tellseq.*gz
+        run: harpy convert fastq --quiet 2 -o convert_tellseq/haptag haplotagging convert/tellseq.*gz
       - name: convert tellseq to standard
         shell: micromamba-shell {0}
         run: |
-          harpy convert fastq --quiet 2 -o convert_tellseq/standard tellseq standard convert/tellseq.*gz
+          harpy convert fastq --quiet 2 -o convert_tellseq/standard standard convert/tellseq.*gz
           rm -rf convert_tellseq
       - name: convert standard to 10x
         shell: micromamba-shell {0}
-        run: harpy convert fastq --quiet 2 -o convert_standard/10x standard 10x test/fastq/sample1.*gz
+        run: harpy convert fastq --quiet 2 -o convert_standard/10x 10x test/fastq/sample1.*gz
       - name: convert standard to stlfr
         shell: micromamba-shell {0}
-        run: harpy convert fastq --quiet 2 -o convert_standard/stlfr standard stlfr test/fastq/sample1.*gz
+        run: harpy convert fastq --quiet 2 -o convert_standard/stlfr stlfr test/fastq/sample1.*gz
       - name: convert standard to tellseq
         shell: micromamba-shell {0}
         run: |
-          harpy convert fastq --quiet 2 -o convert_standard/haptag standard tellseq test/fastq/sample1.*gz
+          harpy convert fastq --quiet 2 -o convert_standard/haptag tellseq test/fastq/sample1.*gz
           rm -rf convert_standard
       - name: convert 10x to standard
         shell: micromamba-shell {0}
         run: |
           cut -f2 convert/10x.bc | grep -v "N" > 10x.barcodes && \
-          harpy convert fastq --quiet 2 -o convert_10x/standard -b 10x.barcodes 10x standard convert/10x*gz
+          harpy convert fastq --quiet 2 -o convert_10x/standard -b 10x.barcodes standard convert/10x*gz
       - name: convert 10x to haplotagging
         shell: micromamba-shell {0}
-        run: harpy convert fastq --quiet 2 -o convert_10x/haptag -b 10x.barcodes 10x haplotagging convert/10x*gz
+        run: harpy convert fastq --quiet 2 -o convert_10x/haptag -b 10x.barcodes haplotagging convert/10x*gz
       - name: convert 10x to tellseq
         shell: micromamba-shell {0}
-        run: harpy convert fastq --quiet 2 -o convert_10x/tellseq -b 10x.barcodes 10x tellseq convert/10x*gz
+        run: harpy convert fastq --quiet 2 -o convert_10x/tellseq -b 10x.barcodes tellseq convert/10x*gz
       - name: convert 10x to stlfr
         shell: micromamba-shell {0}
         run: |
-          harpy convert fastq --quiet 2 -o convert_10x/stlfr -b 10x.barcodes 10x stlfr convert/10x*gz
+          harpy convert fastq --quiet 2 -o convert_10x/stlfr -b 10x.barcodes stlfr convert/10x*gz
           rm -rf convert_10x
 
       - name: convert BAM haplotagging to tellseq
         shell: micromamba-shell {0}
         run: |
-          harpy convert bam --quiet 2 tellseq test/bam/sample1.bam > tellseq.bam && \
+          harpy convert standardize-bam --quiet 2 --convert tellseq test/bam/sample1.bam > tellseq.bam && \
           samtools view tellseq.bam | head -3
       - name: convert BAM haplotagging to stlfr
         shell: micromamba-shell {0}
         run: |
-          harpy convert bam --quiet 2 stlfr test/bam/sample1.bam > stlfr.bam && \
+          harpy convert standardize-bam --quiet 2 --convert stlfr test/bam/sample1.bam > stlfr.bam && \
           samtools view stlfr.bam | head -3
       - name: convert BAM stlfr to haplotagging
         shell: micromamba-shell {0}
         run: |
-          harpy convert bam --quiet 2 haplotagging stlfr.bam > test.bam && \
+          harpy convert standardize-bam --quiet 2 --convert haplotagging stlfr.bam > test.bam && \
           samtools view test.bam | head -3
       - name: convert BAM stlfr to tellseq
         shell: micromamba-shell {0}
         run: |
-          harpy convert bam --quiet 2 tellseq stlfr.bam > test.bam && \
+          harpy convert standardize-bam --quiet 2 --convert tellseq stlfr.bam > test.bam && \
           samtools view test.bam | head -3
       - name: convert BAM tellseq to haplotagging
         shell: micromamba-shell {0}
         run: |
-          harpy convert bam --quiet 2 haplotagging tellseq.bam > test.bam && \
+          harpy convert standardize-bam --quiet 2 --convert haplotagging tellseq.bam > test.bam && \
           samtools view test.bam | head -3
       - name: convert BAM tellseq to stlfr
         shell: micromamba-shell {0}
         run: |
-          harpy convert bam --quiet 2 stlfr tellseq.bam > test.bam && \
+          harpy convert standardize-bam --quiet 2 --convert stlfr tellseq.bam > test.bam && \
           samtools view test.bam | head -3

--- a/harpy/commands/align.py
+++ b/harpy/commands/align.py
@@ -58,7 +58,7 @@ docstring = {
     ]
 }
 
-@click.command(no_args_is_help = True, epilog= "Documentation: https://pdimens.github.io/harpy/workflows/align/bwa/")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog= "Documentation: https://pdimens.github.io/harpy/workflows/align/bwa/")
 @click.option('-w', '--depth-window', default = 50000, show_default = True, type = click.IntRange(min = 50), help = 'Interval size (in bp) for depth stats')
 @click.option('-x', '--extra-params', type = BwaParams(), help = 'Additional bwa mem parameters, in quotes')
 @click.option('-u', '--keep-unmapped',  is_flag = True, default = False, help = 'Include unmapped sequences in output')
@@ -137,7 +137,7 @@ def bwa(reference, inputs, output_dir, depth_window, lr_type, threads, keep_unma
 
     workflow.initialize(setup_only)
 
-@click.command(no_args_is_help = True, epilog= "Documentation: https://pdimens.github.io/harpy/workflows/align/strobe/")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog= "Documentation: https://pdimens.github.io/harpy/workflows/align/strobe/")
 @click.option('-w', '--depth-window', default = 50000, show_default = True, type = click.IntRange(min = 50), help = 'Interval size (in bp) for depth stats')
 @click.option('-x', '--extra-params', type = StrobeAlignParams(), help = 'Additional strobealign parameters, in quotes')
 @click.option('-u', '--keep-unmapped',  is_flag = True, default = False, help = 'Include unmapped sequences in output')

--- a/harpy/commands/assembly.py
+++ b/harpy/commands/assembly.py
@@ -1,7 +1,7 @@
 """Perform a linked-read aware metassembly"""
 
 import rich_click as click
-from harpy.common.cli_filetypes import HPCProfile
+from harpy.common.cli_filetypes import HPCProfile, FASTQfile
 from harpy.common.cli_types_generic import KParam, SnakemakeParams
 from harpy.common.cli_types_params import SpadesParams, ArcsParams
 from harpy.common.misc import container_ok
@@ -56,8 +56,8 @@ docstring = {
 @click.option('--setup-only',  is_flag = True, hidden = True, default = False, help = 'Setup the workflow and exit')
 @click.option('--skip-reports',  is_flag = True, show_default = True, default = False, help = 'Don\'t generate HTML reports')
 @click.option('--snakemake', type = SnakemakeParams(), help = 'Additional Snakemake parameters, in quotes')
-@click.argument('fastq_r1', required=True, type=click.Path(exists=True, readable=True, resolve_path=True), nargs=1)
-@click.argument('fastq_r2', required=True, type=click.Path(exists=True, readable=True, resolve_path=True), nargs=1)
+@click.argument('fastq_r1', required=True, type=FASTQfile(single=True), nargs=1)
+@click.argument('fastq_r2', required=True, type=FASTQfile(single=True), nargs=1)
 def assembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, output_dir, extra_params,arcs_extra,contig_length,links,min_quality,min_aligned,mismatch,molecule_distance,molecule_length,seq_identity,span, organism_type, container, threads, snakemake, quiet, hpc, setup_only, skip_reports):
     """
     Assemble linked reads into a genome

--- a/harpy/commands/assembly.py
+++ b/harpy/commands/assembly.py
@@ -29,7 +29,7 @@ docstring = {
     ]
 }
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/assembly")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/assembly")
 # SPADES
 @click.option('-b', '--bx-tag', type = click.Choice(['BX', 'BC'], case_sensitive=False), default = "BX", show_default=True, help = "The header tag with the barcode [`BX`,`BC`]")
 @click.option('-k', '--kmer-length', type = KParam(), show_default = True, default = "auto", help = 'K values to use for assembly (`odd` and `<128`)')

--- a/harpy/commands/convert.py
+++ b/harpy/commands/convert.py
@@ -10,7 +10,7 @@ import sys
 import rich_click as click
 import pysam
 from harpy.common.misc import safe_read, harpy_pulsebar
-from harpy.common.convert import FQRecord, compress_fq
+from harpy.common.convert import FQRecord, compress_fq, INVALID_10x, INVALID_HAPLOTAGGING, INVALID_STLFR, INVALID_TELLSEQ
 from harpy.common.printing import print_error
 from harpy.common.misc import validate_barcodefile, is_xam, is_fastq, which_linkedread
 
@@ -29,11 +29,6 @@ module_docstring = {
         }
     ]
 }
-
-INVALID_10x = "N" * 16
-INVALID_HAPLOTAGGING = "A00C00B00D00"
-INVALID_STLFR = "0_0_0"
-INVALID_TELLSEQ = "N" * 18
 
 @click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/convert")
 @click.option('--standardize',  is_flag = True, default = False, help = 'Add barcode validation tag `VX:i` to output')
@@ -348,7 +343,7 @@ def standardize_fastq(prefix, r1_fastq, r2_fastq, convert, quiet):
     Use `--convert` to also convert the barcode to a different style (`haplotagging`, `stlfr`, `tellseq`, `10X`).
 
     **Barcode Styles for --convert**
-    | Style          | Format                                         |
+    | Option         | Format                                         |
     |:---------------|:-----------------------------------------------|
     | `haplotagging` | : AxxCxxBxxDxx                                 |
     | `stlfr`        | : 1_2_3                                        |
@@ -358,7 +353,7 @@ def standardize_fastq(prefix, r1_fastq, r2_fastq, convert, quiet):
     for i in [r1_fastq, r2_fastq]:
         if not is_fastq(i):
             print_error("Unrecognized file type", f"[blue]{os.path.basename(i)}[/] was unable to be processed by samtools, suggesting it is not a FASTQ file.")
-    logtext = f"Standardizing [->[magenta]{convert.lower()}[/]]" if convert else "Standardizing"
+    logtext = f"Standardizing [dim][-> [magenta]{convert.lower()}[/]][/]" if convert else "Standardizing"
 
     BC_TYPE = which_linkedread(r1_fastq)
     if not BC_TYPE:
@@ -445,9 +440,6 @@ def standardize_fastq(prefix, r1_fastq, r2_fastq, convert, quiet):
         with ThreadPoolExecutor(max_workers=2) as executor:
             executor.submit(compress_fq, f"{prefix}.R1.fq")
             executor.submit(compress_fq, f"{prefix}.R2.fq")
-
-    
-
 
 @click.command(hidden = True, no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/ncbi")
 @click.option('-m', '--barcode-map',  is_flag = True, default = False, help = 'Write a map of the barcode-to-nucleotide conversion')

--- a/harpy/commands/deconvolve.py
+++ b/harpy/commands/deconvolve.py
@@ -24,7 +24,7 @@ docstring = {
     ]
 }
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/qc")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/qc")
 @click.option('-k', '--kmer-length', default = 21, show_default = True, type=click.IntRange(min = 1), help = 'Size of kmers')
 @click.option('-w', '--window-size', default = 40, show_default = True, type=click.IntRange(min = 3), help = 'Size of window guaranteed to contain at least one kmer')
 @click.option('-d', '--density', default = 3, show_default = True, type = click.IntRange(min = 1), help = 'On average, 1/2^d kmers are indexed')

--- a/harpy/commands/demultiplex.py
+++ b/harpy/commands/demultiplex.py
@@ -53,7 +53,7 @@ def gen1():
     """
     print_error("deprecated command", "This workflow has been renamed \"meier2021\"-- please use that instead. This warning will be removed in the next minor Harpy version and will only return an error.")
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/demultiplex/")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/demultiplex/")
 @click.option('-u', '--keep-unknown-samples',  is_flag = True, default = False, help = 'Keep a separate file of reads with recognized barcodes but don\'t match any sample in the schema')
 @click.option('-b', '--keep-unknown-barcodes',  is_flag = True, default = False, help = 'Keep a separate file of reads with unrecognized barcodes')
 @click.option('-q', '--qx-rx', is_flag = True, default = False, help = 'Include the `QX:Z` and `RX:Z` tags in the read header')

--- a/harpy/commands/diagnose.py
+++ b/harpy/commands/diagnose.py
@@ -5,7 +5,7 @@ import subprocess
 import rich_click as click
 from harpy.common.printing import print_error, CONSOLE
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False))
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False})
 @click.argument('directory', required=True, type=click.Path(exists=True, file_okay=False))
 def diagnose(directory):
     """

--- a/harpy/commands/downsample.py
+++ b/harpy/commands/downsample.py
@@ -23,7 +23,7 @@ docstring = {
     ]
 }
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/downsample")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/downsample")
 @click.option('-b', '--barcode-tag', type = str, default = "BX", show_default = True, help = 'Tag that contains the barcode')
 @click.option('-d', '--downsample', type = click.FloatRange(min = 0.0000001), help = 'Number/fraction of barcodes to retain')
 @click.option('-i', '--invalid', default = 1, show_default = True, type=click.FloatRange(min=0,max=1), help = "Proportion of invalid barcodes to sample")

--- a/harpy/commands/impute.py
+++ b/harpy/commands/impute.py
@@ -27,7 +27,7 @@ docstring = {
     ]
 }
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/impute/")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/impute/")
 @click.option('-x', '--extra-params', type = StitchParams(), help = 'Additional STITCH parameters, in quotes')
 @click.option('-o', '--output-dir', type = click.Path(exists = False, resolve_path = True), default = "Impute", show_default=True,  help = 'Output directory name')
 @click.option('-t', '--threads', default = 4, show_default = True, type = click.IntRange(2,999, clamp = True), help = 'Number of threads to use')

--- a/harpy/commands/metassembly.py
+++ b/harpy/commands/metassembly.py
@@ -1,7 +1,7 @@
 """Perform a linked-read aware metassembly"""
 
 import rich_click as click
-from harpy.common.cli_filetypes import HPCProfile
+from harpy.common.cli_filetypes import HPCProfile, FASTQfile
 from harpy.common.cli_types_generic import KParam, SnakemakeParams
 from harpy.common.cli_types_params import SpadesParams
 from harpy.common.misc import container_ok
@@ -41,8 +41,8 @@ docstring = {
 @click.option('--setup-only',  is_flag = True, hidden = True, default = False, help = 'Setup the workflow and exit')
 @click.option('--skip-reports',  is_flag = True, show_default = True, default = False, help = 'Don\'t generate HTML reports')
 @click.option('--snakemake', type = SnakemakeParams(), help = 'Additional Snakemake parameters, in quotes')
-@click.argument('fastq_r1', required=True, type=click.Path(exists=True, readable=True, resolve_path=True), nargs=1)
-@click.argument('fastq_r2', required=True, type=click.Path(exists=True, readable=True, resolve_path=True), nargs=1)
+@click.argument('fastq_r1', required=True, type=FASTQfile(single=True), nargs=1)
+@click.argument('fastq_r2', required=True, type=FASTQfile(single=True), nargs=1)
 def metassembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, lr_type, output_dir, extra_params, container, threads, snakemake, quiet, hpc, organism_type, setup_only, skip_reports):
     """
     Assemble linked reads into a metagenome

--- a/harpy/commands/metassembly.py
+++ b/harpy/commands/metassembly.py
@@ -24,7 +24,7 @@ docstring = {
     ]
 }
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/metassembly")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/metassembly")
 # SPADES
 @click.option('-b', '--bx-tag', type = click.Choice(['BX', 'BC'], case_sensitive=False), default = "BX", show_default=True, help = "The header tag with the barcode (`BX` or `BC`)")
 @click.option('-k', '--kmer-length', type = KParam(), show_default = True, default = "auto", help = 'K values to use for assembly (`odd` and `<128`)')

--- a/harpy/commands/phase.py
+++ b/harpy/commands/phase.py
@@ -27,7 +27,7 @@ docstring = {
     ]
 }
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/phase")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/phase")
 @click.option('-x', '--extra-params', type = HapCutParams(), help = 'Additional HapCut2 parameters, in quotes')
 @click.option('-r', '--reference', type=FASTAfile(), help = 'Path to reference genome if wanting to also extract reads spanning indels')
 @click.option('-q', '--min-map-quality', default = 20, show_default = True, type = click.IntRange(0, 40, clamp = True), help = 'Minimum mapping quality for phasing')

--- a/harpy/commands/qc.py
+++ b/harpy/commands/qc.py
@@ -25,7 +25,7 @@ docstring = {
     ]
 }
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/qc")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/qc")
 @click.option('-c', '--deconvolve', type = MultiInt(4), help = "`k` `w` `d` `a` QuickDeconvolution parameters, comma-separated")
 @click.option('-d', '--deduplicate', is_flag = True, default = False, help = 'Identify and remove PCR duplicates')
 @click.option('-x', '--extra-params', type = FastpParams(), help = 'Additional Fastp parameters, in quotes')

--- a/harpy/commands/resume.py
+++ b/harpy/commands/resume.py
@@ -9,7 +9,7 @@ from harpy.common.conda import check_environments, create_conda_recipes
 from harpy.common.printing import print_error, workflow_info
 from harpy.common.workflow import Workflow
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/other")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/other")
 @click.option('-c', '--conda',  is_flag = True, default = False, help = 'Recreate the conda environments')
 @click.option('-r', '--relative',  is_flag = True, default = False, help = 'Call Snakemake with relative paths')
 @click.option('-t', '--threads', type = click.IntRange(2, 999, clamp = True), help = 'Change the number of threads (>1)')

--- a/harpy/commands/simulate_linkedreads.py
+++ b/harpy/commands/simulate_linkedreads.py
@@ -29,7 +29,7 @@ docstring = {
     ]
 }
 
-@click.command(epilog = "Documentation: https://pdimens.github.io/mimick/", no_args_is_help = True)
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/mimick/")
 #Paired-end FASTQ simulation using pywgsim
 @click.option('--coverage', help='mean coverage (depth) target for simulated data', show_default=True, default=30, type=click.FloatRange(min=0.05))
 @click.option('--distance', help='outer distance between the two read ends in bp', default=500, show_default=True, type=click.IntRange(min=0))

--- a/harpy/commands/simulate_variants.py
+++ b/harpy/commands/simulate_variants.py
@@ -108,7 +108,7 @@ docstring = {
     ]
 }
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "This workflow can be quite technical, please read the docs for more information: https://pdimens.github.io/harpy/workflows/simulate/simulate-variants")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "This workflow can be quite technical, please read the docs for more information: https://pdimens.github.io/harpy/workflows/simulate/simulate-variants")
 @click.option('-s', '--snp-vcf', type=VCFfile(gzip_ok = False), help = 'VCF file of known snps to simulate')
 @click.option('-i', '--indel-vcf', type=VCFfile(gzip_ok = False), help = 'VCF file of known indels to simulate')
 @click.option('-n', '--snp-count', type = click.IntRange(min = 0), default=0, show_default=False, help = "Number of random snps to simluate")
@@ -217,7 +217,7 @@ def snpindel(genome, snp_vcf, indel_vcf, only_vcf, output_dir, prefix, snp_count
 
     workflow.initialize(setup_only)
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Please Documentation: https://pdimens.github.io/harpy/workflows/simulate/simulate-variants")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Please Documentation: https://pdimens.github.io/harpy/workflows/simulate/simulate-variants")
 @click.option('-v', '--vcf', type=VCFfile(gzip_ok = False), help = 'VCF file of known inversions to simulate')
 @click.option('-n', '--count', type = click.IntRange(min = 0), default=0, show_default=False, help = "Number of random inversions to simluate")
 @click.option('-m', '--min-size', type = click.IntRange(min = 1), default = 1000, show_default= True, help = "Minimum inversion size (bp)")
@@ -298,7 +298,7 @@ def inversion(genome, vcf, only_vcf, prefix, output_dir, count, min_size, max_si
 
     workflow.initialize(setup_only)
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Please Documentation: https://pdimens.github.io/harpy/workflows/simulate/simulate-variants")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Please Documentation: https://pdimens.github.io/harpy/workflows/simulate/simulate-variants")
 @click.option('-v', '--vcf', type=VCFfile(gzip_ok = False), help = 'VCF file of known copy number variants to simulate')
 @click.option('-n', '--count', type = click.IntRange(min = 0), default=0, show_default=False, help = "Number of random variants to simluate")
 @click.option('-m', '--min-size', type = click.IntRange(min = 1), default = 1000, show_default= True, help = "Minimum variant size (bp)")
@@ -392,7 +392,7 @@ def cnv(genome, output_dir, vcf, only_vcf, prefix, count, min_size, max_size, du
 
     workflow.initialize(setup_only)
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Please Documentation: https://pdimens.github.io/harpy/workflows/simulate/simulate-variants")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Please Documentation: https://pdimens.github.io/harpy/workflows/simulate/simulate-variants")
 @click.option('-v', '--vcf', type=VCFfile(gzip_ok = False), help = 'VCF file of known translocations to simulate')
 @click.option('-n', '--count', type = click.IntRange(min = 0), default=0, show_default=False, help = "Number of random translocations to simluate")
 @click.option('-c', '--centromeres', type = InputFile("gff", gzip_ok = True), help = "GFF3 file of centromeres to avoid")

--- a/harpy/commands/snp.py
+++ b/harpy/commands/snp.py
@@ -62,7 +62,7 @@ docstring = {
 } |  module_docstring
 
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/snp")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/snp")
 @click.option('-x', '--extra-params', type = FreebayesParams(), help = 'Additional freebayes parameters, in quotes')
 @click.option('-o', '--output-dir', type = click.Path(exists = False, resolve_path= True), default = "SNP/freebayes", show_default=True,  help = 'Output directory name')
 @click.option('-n', '--ploidy', default = 2, show_default = True, type=click.IntRange(min=1), help = 'Ploidy of samples')
@@ -141,7 +141,7 @@ def freebayes(reference, inputs, output_dir, threads, populations, ploidy, regio
 
     workflow.initialize(setup_only)
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/snp")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/snp")
 @click.option('-x', '--extra-params', type = MpileupParams(), help = 'Additional mpileup parameters, in quotes')
 @click.option('-o', '--output-dir', type = click.Path(exists = False, resolve_path=True), default = "SNP/mpileup", show_default=True,  help = 'Output directory name')
 @click.option('-n', '--ploidy', default = 2, show_default = True, type=click.IntRange(1, 2), help = 'Ploidy of samples')

--- a/harpy/commands/sv.py
+++ b/harpy/commands/sv.py
@@ -64,7 +64,7 @@ docstring = {
     ]
 } | module_docstring
 
-@click.command(no_args_is_help = True, epilog= "Documentation: https://pdimens.github.io/harpy/workflows/sv/leviathan/")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog= "Documentation: https://pdimens.github.io/harpy/workflows/sv/leviathan/")
 @click.option('-x', '--extra-params', type = LeviathanParams(), help = 'Additional leviathan parameters, in quotes')
 @click.option('-i', '--iterations', show_default = True, default=50, type = click.IntRange(min = 10), help = 'Number of iterations to perform through index (reduces memory)')
 @click.option('-d', '--duplicates', show_default = True, default=10, type = click.IntRange(min = 1), help = 'Consider SV of the same type as duplicates if their breakpoints are within this distance')
@@ -149,7 +149,7 @@ def leviathan(inputs, output_dir, reference, min_size, min_barcodes, iterations,
 
     workflow.initialize(setup_only)
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/sv/naibr/")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/sv/naibr/")
 @click.option('-x', '--extra-params', type = NaibrParams(), help = 'Additional naibr parameters, in quotes')
 @click.option('-b', '--min-barcodes', show_default = True, default=2, type = click.IntRange(min = 1), help = 'Minimum number of barcode overlaps supporting candidate SV')
 @click.option('-q', '--min-quality', show_default = True, default=30, type = click.IntRange(min = 0, max = 40), help = 'Minimum mapping quality of reads to use')

--- a/harpy/commands/template.py
+++ b/harpy/commands/template.py
@@ -31,7 +31,7 @@ def template():
     All subcommands write to `stdout`.
     """
 
-@click.command(context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/snp/#sample-grouping-file")
+@click.command(context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/snp/#sample-grouping-file")
 @click.argument('inputdir', required=True, type=click.Path(exists=True, file_okay=False))
 def groupings(inputdir):
     """
@@ -70,7 +70,7 @@ def groupings(inputdir):
         _ = sys.stdout.write(f'{i}\tpop1\n')
     print_notice("Please review the resulting file, as all samples have been grouped into a single population")
 
-@click.command(context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/impute/#parameter-file")
+@click.command(context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/impute/#parameter-file")
 def impute():
     """
     Create a template imputation parameter file

--- a/harpy/commands/validate.py
+++ b/harpy/commands/validate.py
@@ -47,7 +47,7 @@ docstring = {
     ]
 }
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/validate/")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/validate/")
 @click.option('-L', '--lr-type', type = click.Choice(['haplotagging', 'stlfr','tellseq'], case_sensitive=False), default = "haplotagging", show_default=True, help = "Linked read type\n[haplotagging, stlfr, tellseq]")
 @click.option('-t', '--threads', default = 4, show_default = True, type = click.IntRange(1, 999, clamp = True), help = 'Number of threads to use')
 @click.option('-o', '--output-dir', type = click.Path(exists = False, resolve_path = True), default = "Validate/bam", show_default=True,  help = 'Output directory name')
@@ -96,7 +96,7 @@ def bam(inputs, lr_type, output_dir, threads, snakemake, quiet, hpc, container, 
 
     workflow.initialize(setup_only)
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False), epilog = "Documentation: https://pdimens.github.io/harpy/workflows/validate/")
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/validate/")
 @click.option('-o', '--output-dir', type = click.Path(exists = False, resolve_path = True), default = "Validate/fastq", show_default=True,  help = 'Output directory name')
 @click.option('-L', '--lr-type', type = click.Choice(['haplotagging', 'stlfr','tellseq'], case_sensitive=False), default = "haplotagging", show_default=True, help = "Linked read type\n[haplotagging, stlfr, tellseq]")
 @click.option('-t', '--threads', default = 4, show_default = True, type = click.IntRange(1, 999, clamp = True), help = 'Number of threads to use')

--- a/harpy/commands/view.py
+++ b/harpy/commands/view.py
@@ -79,7 +79,7 @@ def view():
     file, workflow config file in a directory that was used for the output of a Harpy run.
     """
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False))
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False})
 @click.option("-e", "--edit", is_flag=True, default=False, help = "Open the config file in you system's default editor")
 @click.argument('directory', required=True, type=click.Path(exists=True, file_okay=False), nargs=1)
 def config(directory, edit):
@@ -164,7 +164,7 @@ def environments(program):
             console.print()
     return
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False))
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False})
 @click.argument('directory', required=True, type=click.Path(exists=True, file_okay=False), nargs=1)
 def log(directory):
     """
@@ -207,7 +207,7 @@ def log(directory):
         file = sys.stderr
     )
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False))
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False})
 @click.option("-e", "--edit", is_flag=True, default=False, help = "Open the config file in you system's default editor")
 @click.argument('directory', required=True, type=click.Path(exists=True, file_okay=False), nargs=1)
 def snakefile(directory, edit):
@@ -245,7 +245,7 @@ def snakefile(directory, edit):
         file = sys.stderr
     )
 
-@click.command(no_args_is_help = True, context_settings=dict(allow_interspersed_args=False))
+@click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False})
 @click.option("-e", "--edit", is_flag=True, default=False, help = "Open the config file in you system's default editor")
 @click.argument('directory', required=True, type=click.Path(exists=True, file_okay=False), nargs=1)
 def snakeparams(directory, edit):

--- a/harpy/common/cli_filetypes.py
+++ b/harpy/common/cli_filetypes.py
@@ -12,9 +12,11 @@ from harpy.common.printing import print_error, print_notice
 class SAMfile(click.ParamType):
     """A CLI class to validate a BAM/SAM file as input. Checks for presence, format, and returns the absolute path"""
     name = "bam_file"
-    def __init__(self, dir_ok: bool = True):
+    def __init__(self, dir_ok: bool = True, single: bool = False):
         super().__init__()
         self.dir_ok = dir_ok
+        self.single = single
+
     def convert(self, value, param, ctx):
         filepath = Path(value)
         if filepath.is_dir() and not self.dir_ok:
@@ -42,7 +44,10 @@ class SAMfile(click.ParamType):
                     pass
             except (ValueError, OSError):
                 self.fail(f"File {value} was not recognized as being in BAM/SAM format.", param, ctx)
-        return infiles
+        if self.single:
+            return infiles[0]
+        else:
+            return infiles
 
 class FASTAfile(click.ParamType):
     """A CLI class to validate a FASTA file as input. Checks for presence, format, and returns the absolute path"""
@@ -66,11 +71,15 @@ class FASTAfile(click.ParamType):
             self.fail(f"File {value} was not recognized as being in FASTA format.", param, ctx)
         
 class FASTQfile(click.ParamType):
-    """A CLI class to validate a FASTQ file as input. Checks for presence, format, and returns the absolute path"""
+    """
+    A CLI class to validate a FASTQ file as input. Checks for presence, format, and returns the absolute path.
+    Setting single to True returns a str, otherwise returns a list.
+    """
     name = "fastq_file"
-    def __init__(self, dir_ok: bool = True):
+    def __init__(self, dir_ok: bool = True, single: bool = False):
         super().__init__()
         self.dir_ok = dir_ok
+        self.single = single
 
     def convert(self, value, param, ctx):
         filepath = Path(value)
@@ -103,7 +112,11 @@ class FASTQfile(click.ParamType):
                         break
             except (ValueError, OSError):
                 self.fail(f"File {fastq} was not recognized as being in FASTQ format.", param, ctx)
-        return infiles
+        if self.single:
+            return infiles[0]
+        else:
+            return infiles
+
 
 class VCFfile(click.ParamType):
     """A CLI class to validate a VCF/BCF file as input. Checks for presence, format, and returns the absolute path"""

--- a/harpy/common/convert.py
+++ b/harpy/common/convert.py
@@ -5,9 +5,10 @@ import pysam
 import re
 from .printing import print_error
 
+INVALID_10x = "N" * 16
+INVALID_HAPLOTAGGING = "A00C00B00D00"
 INVALID_STLFR = "0_0_0"
 INVALID_TELLSEQ = "N" * 18
-INVALID_HAPLOTAGGING = "A00C00B00D00"
 
 stlfrINVALID = re.compile("^0_|_0_|_0$")
 

--- a/harpy/common/convert.py
+++ b/harpy/common/convert.py
@@ -2,14 +2,18 @@
 
 import os
 import pysam
+import re
 from .printing import print_error
 
 INVALID_STLFR = "0_0_0"
 INVALID_TELLSEQ = "N" * 18
 INVALID_HAPLOTAGGING = "A00C00B00D00"
 
+stlfrINVALID = re.compile("^0_|_0_|_0$")
+
 class FQRecord():
     def __init__(self, pysamfq, FORWARD: bool, bc: str, length: int):
+        """Initialize a FASTQ record. FORWARD denotes if it's a forward read, bc is the barcode type, length is the length"""
         self.forward = FORWARD
         fr = "1:N:" if self.forward else "2:N:"
         comments = pysamfq.comment.strip().split()
@@ -33,7 +37,7 @@ class FQRecord():
                 _id = pysamfq.name.split("#")
                 self.barcode = _id.pop(-1)
                 self.id = "#".join(_id)
-                self.valid = "_0" not in self.barcode
+                self.valid = not bool(stlfrINVALID.search(self.barcode))
         elif bc == "10x":
             # identify the first N bases and remove it from the seq and qual of R1
             if self.forward:
@@ -90,7 +94,11 @@ class FQRecord():
             self.id += f"#{BC} {self.illumina_new}"
         elif _type in ["haplotagging", "standard"]:
             self.id += self.illumina_old
-            self.comment += f"\tBX:Z:{BC}"
+            if not self.comment:
+                self.comment = f"VX:i:{int(self.valid)}\tBX:Z:{BC}"
+            else:
+                _comments = [i for i in self.comment.split() if not i.startswith("BX") and not i.startswith("VX")] + [f"VX:i:{int(self.valid)}", f"BX:Z:{BC}"]
+                self.comment = "\t".join(_comments)
         return self
 
 def compress_fq(fq: str):

--- a/harpy/common/misc.py
+++ b/harpy/common/misc.py
@@ -241,29 +241,6 @@ def is_bgzipped(file_path: str) -> bool:
     except (IOError, OSError):
         return False
 
-def is_xam(file_path: str) -> bool:
-    try:
-        with pysam.AlignmentFile(file_path, require_index=False) as xam:
-            for i in xam:
-                if not i.query_qualities:
-                    raise ValueError
-                break
-    except ValueError:
-            return False
-    return True
-
-
-def is_fastq(file_path: str) -> bool:
-    try:
-        with pysam.FastxFile(file_path, persist=False) as fq:
-            for i in fq:
-                if not i.quality:
-                    raise ValueError
-                break
-    except ValueError:
-            return False
-    return True
-
 def is_plaintext(file_path: str) -> bool:
     """helper function to determine if a file is plaintext"""
     try:


### PR DESCRIPTION
This PR renames `convert standardize` into two commands:

- `convert standardize-bam`: which performs the function that `convert standardize` did previously PLUS `convert bam`, meaning `convert bam` no longer exists and has been integrated into standardization
- `convert standardize-fastq`: which auto-detects the linked-read type and standardizes it. Can optionally convert the barcode type to a different format

Also:
- adds the `VX` tag to `convert fastq ... standard`
- minor touchups here and there