### PR TITLE
automagical detection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -726,7 +726,7 @@ jobs:
       - name: test metassembly without barcodes
         shell: micromamba-shell {0}
         run: |
-          harpy metassembly --lr-type none --quiet 2 -r 4000 test/fastq/sample1.* && \
+          harpy metassembly --unlinked --quiet 2 -r 4000 test/fastq/sample1.* && \
           ls -lh Metassembly
 
   other:

--- a/harpy/commands/align.py
+++ b/harpy/commands/align.py
@@ -47,7 +47,7 @@ docstring = {
     "harpy align strobe": [
         {
             "name": "Parameters",
-            "options": ["--extra-params", "--keep-unmapped", "--molecule-distance", "--min-quality", "--read-length", "--unlinked"],
+            "options": ["--extra-params", "--keep-unmapped", "--molecule-distance", "--min-quality", "--unlinked"],
             "panel_styles": {"border_style": "blue"}
         },
         {
@@ -104,7 +104,7 @@ def bwa(reference, inputs, output_dir, depth_window, unlinked, threads, keep_unm
         "keep_unmapped" : keep_unmapped,
         "depth_windowsize" : depth_window,
         "linkedreads": {
-            "type" : fastq.lr_type == "none",
+            "type" : fastq.lr_type,
             "standardized": fastq.bx_tag,
             "distance_threshold" : molecule_distance,
         },
@@ -182,7 +182,7 @@ def strobe(reference, inputs, output_dir, unlinked, keep_unmapped, depth_window,
         "keep_unmapped" : keep_unmapped,
         "depth_windowsize" : depth_window,
         "linkedreads": {
-            "type" : fastq.lr_type == "none",
+            "type" : fastq.lr_type,
             "standardized": fastq.bx_tag,
             "distance_threshold" : molecule_distance,
         },

--- a/harpy/commands/align.py
+++ b/harpy/commands/align.py
@@ -35,7 +35,7 @@ docstring = {
     "harpy align bwa": [
         {
             "name": "Parameters",
-            "options": ["--extra-params", "--keep-unmapped", "--lr-type", "--molecule-distance", "--min-quality"],
+            "options": ["--extra-params", "--keep-unmapped", "--molecule-distance", "--min-quality", "--unlinked"],
             "panel_styles": {"border_style": "blue"}
         },
         {
@@ -47,7 +47,7 @@ docstring = {
     "harpy align strobe": [
         {
             "name": "Parameters",
-            "options": ["--extra-params", "--keep-unmapped", "--lr-type", "--molecule-distance", "--min-quality", "--read-length"],
+            "options": ["--extra-params", "--keep-unmapped", "--molecule-distance", "--min-quality", "--read-length", "--unlinked"],
             "panel_styles": {"border_style": "blue"}
         },
         {
@@ -62,11 +62,11 @@ docstring = {
 @click.option('-w', '--depth-window', default = 50000, show_default = True, type = click.IntRange(min = 50), help = 'Interval size (in bp) for depth stats')
 @click.option('-x', '--extra-params', type = BwaParams(), help = 'Additional bwa mem parameters, in quotes')
 @click.option('-u', '--keep-unmapped',  is_flag = True, default = False, help = 'Include unmapped sequences in output')
-@click.option('-L', '--lr-type', type = click.Choice(['none'], case_sensitive=False), show_default=False, help = "Ignore linked-read information by setting this to `none`")
-@click.option('-q', '--min-quality', default = 30, show_default = True, type = click.IntRange(0, 40, clamp = True), help = 'Minimum mapping quality to pass filtering')
+@click.option('-q', '--min-quality', default = 30, show_default = True, type = click.IntRange(0, 40, clamp = True), help = 'Minimum mapping quality to output')
 @click.option('-d', '--molecule-distance', default = 0, show_default = True, type = click.IntRange(min = 0), help = 'Distance cutoff for molecule assignment (bp)')
 @click.option('-o', '--output-dir', type = click.Path(exists = False, resolve_path = True), default = "Align/bwa", show_default=True,  help = 'Output directory name')
 @click.option('-t', '--threads', default = 4, show_default = True, type = click.IntRange(4,999, clamp = True), help = 'Number of threads to use')
+@click.option('-U','--unlinked', is_flag = True, default = False, help = "Treat input data as not linked reads")
 @click.option('--container',  is_flag = True, default = False, help = 'Use a container instead of conda', callback=container_ok)
 @click.option('--contigs',  type = ContigList(), help = 'File or list of contigs to plot')
 @click.option('--setup-only',  is_flag = True, hidden = True, default = False, help = 'Setup the workflow and exit')
@@ -76,7 +76,7 @@ docstring = {
 @click.option('--snakemake', type = SnakemakeParams(), help = 'Additional Snakemake parameters, in quotes')
 @click.argument('reference', type=FASTAfile(), required = True, nargs = 1)
 @click.argument('inputs', required=True, type=FASTQfile(), nargs=-1)
-def bwa(reference, inputs, output_dir, depth_window, lr_type, threads, keep_unmapped, extra_params, min_quality, molecule_distance, snakemake, skip_reports, quiet, hpc, container, contigs, setup_only):
+def bwa(reference, inputs, output_dir, depth_window, unlinked, threads, keep_unmapped, extra_params, min_quality, molecule_distance, snakemake, skip_reports, quiet, hpc, container, contigs, setup_only):
     """
     Align sequences to reference genome using BWA MEM
  
@@ -84,10 +84,8 @@ def bwa(reference, inputs, output_dir, depth_window, lr_type, threads, keep_unma
     files/folders, using shell wildcards (e.g. `data/echidna*.fastq.gz`), or both.
     
     BWA is a fast, robust, and reliable aligner that does not use barcodes when mapping.
-    Harpy will post-processes the alignments using the specified `--molecule-distance`
-    to assign alignments to unique molecules. A `--molecule-distance` that is `>0` activates
-    alignment-distance based barcode deconvolution. Ignore linked-read information using
-    `-L none` (specifying a technology doesn't matter here).
+    Presence and type of linked-read data is auto-detected, but can be deliberately ignored using `-U`.
+    Setting `--molecule-distance` to `>0` activates alignment-distance based barcode deconvolution.
     """
     workflow = Workflow("align_bwa", "align_bwa.smk", output_dir, quiet)
     workflow.setup_snakemake(container, threads, hpc, snakemake)
@@ -95,21 +93,19 @@ def bwa(reference, inputs, output_dir, depth_window, lr_type, threads, keep_unma
     workflow.conda = ["align", "r", "qc"]
 
     ## checks and validations ##
-    fastq = FASTQ(inputs)
+    fastq = FASTQ(inputs, detect_bc = not unlinked)
     fasta = FASTA(reference)
     if contigs:
-        fasta.match_contigs(contigs)
-    if not lr_type:
-        fastq.has_bx_tag()
+        fasta.match_contigs(contigs) 
 
     workflow.config = {
         "workflow" : workflow.name,
         "alignment_quality" : min_quality,
         "keep_unmapped" : keep_unmapped,
         "depth_windowsize" : depth_window,
-        "barcodes": {
-            "ignore" : isinstance(lr_type, str),
-            "standard_format": fastq.bx_tag,
+        "linkedreads": {
+            "type" : fastq.lr_type == "none",
+            "standardized": fastq.bx_tag,
             "distance_threshold" : molecule_distance,
         },
         **({'extra': extra_params} if extra_params else {}),
@@ -130,7 +126,8 @@ def bwa(reference, inputs, output_dir, depth_window, lr_type, threads, keep_unma
     }
 
     workflow.start_text = workflow_info(
-        ("Samples:", fastq.count),
+        ("Samples:", fastq.count),\
+        ("Linked-Read Type:", fastq.lr_type),
         ("Reference:", os.path.basename(reference)),
         ("Output Folder:", os.path.basename(output_dir) + "/")
     )
@@ -141,11 +138,11 @@ def bwa(reference, inputs, output_dir, depth_window, lr_type, threads, keep_unma
 @click.option('-w', '--depth-window', default = 50000, show_default = True, type = click.IntRange(min = 50), help = 'Interval size (in bp) for depth stats')
 @click.option('-x', '--extra-params', type = StrobeAlignParams(), help = 'Additional strobealign parameters, in quotes')
 @click.option('-u', '--keep-unmapped',  is_flag = True, default = False, help = 'Include unmapped sequences in output')
-@click.option('-L', '--lr-type', type = click.Choice(['none'], case_sensitive=False), help = "Ignore linked-read information by setting this to `none`")
-@click.option('-q', '--min-quality', default = 30, show_default = True, type = click.IntRange(0, 40, clamp = True), help = 'Minimum mapping quality to pass filtering')
+@click.option('-q', '--min-quality', default = 30, show_default = True, type = click.IntRange(0, 40, clamp = True), help = 'Minimum mapping quality to output')
 @click.option('-d', '--molecule-distance', default = 0, show_default = True, type = click.IntRange(min = 0), help = 'Distance cutoff for molecule assignment (bp)')
 @click.option('-o', '--output-dir', type = click.Path(exists = False, resolve_path = True), default = "Align/strobealign", show_default=True,  help = 'Output directory name')
 @click.option('-t', '--threads', default = 4, show_default = True, type = click.IntRange(4,999, clamp = True), help = 'Number of threads to use')
+@click.option('-U','--unlinked', is_flag = True, default = False, help = "Treat input data as not linked reads")
 @click.option('--contigs',  type = ContigList(), help = 'File or list of contigs to plot')
 @click.option('--container',  is_flag = True, default = False, help = 'Use a container instead of conda', callback=container_ok)
 @click.option('--setup-only',  is_flag = True, hidden = True, default = False, help = 'Setup the workflow and exit')
@@ -155,7 +152,7 @@ def bwa(reference, inputs, output_dir, depth_window, lr_type, threads, keep_unma
 @click.option('--snakemake', type = SnakemakeParams(), help = 'Additional Snakemake parameters, in quotes')
 @click.argument('reference', type=FASTAfile(), nargs = 1)
 @click.argument('inputs', required=True, type=FASTQfile(), nargs=-1)
-def strobe(reference, inputs, output_dir, lr_type, keep_unmapped, depth_window, threads, extra_params, min_quality, molecule_distance, snakemake, skip_reports, quiet, hpc, container, contigs, setup_only):
+def strobe(reference, inputs, output_dir, unlinked, keep_unmapped, depth_window, threads, extra_params, min_quality, molecule_distance, snakemake, skip_reports, quiet, hpc, container, contigs, setup_only):
     """
     Align sequences to reference genome using strobealign
  
@@ -163,9 +160,9 @@ def strobe(reference, inputs, output_dir, lr_type, keep_unmapped, depth_window, 
     files/folders, using shell wildcards (e.g. `data/echidna*.fastq.gz`), or both.
     
     strobealign is an ultra-fast aligner comparable to bwa for sequences >100bp and does 
-    not use barcodes when mapping. A `--molecule-distance` that is `>0` activates alignment-distance
-    based barcode deconvolution. Ignore linked-read information using `-L none` (specifying
-    a technology doesn't matter here).
+    not use barcodes when mapping. Presence and type of linked-read data is auto-detected,
+    but can be deliberately ignored using `-U`. Setting `--molecule-distance` to `>0` activates
+    alignment-distance based barcode deconvolution.
     """
     workflow = Workflow("align_strobe", "align_strobe.smk", output_dir, quiet)
     workflow.setup_snakemake(container, threads, hpc, snakemake)
@@ -173,22 +170,20 @@ def strobe(reference, inputs, output_dir, lr_type, keep_unmapped, depth_window, 
     workflow.conda = ["align", "r", "qc"]
 
     ## checks and validations ##
-    fastq = FASTQ(inputs)
+    fastq = FASTQ(inputs, detect_bc= not unlinked)
     fasta = FASTA(reference)
 
     if contigs:
         fasta.match_contigs(contigs)
-    if not lr_type:
-        fastq.has_bx_tag()
 
     workflow.config = {
         "workflow" : workflow.name,
         "alignment_quality" : min_quality,
         "keep_unmapped" : keep_unmapped,
         "depth_windowsize" : depth_window,
-        "barcodes": {
-            "ignore" : isinstance(lr_type, str),
-            "standard_format": fastq.bx_tag,
+        "linkedreads": {
+            "type" : fastq.lr_type == "none",
+            "standardized": fastq.bx_tag,
             "distance_threshold" : molecule_distance,
         },
         **({'extra': extra_params} if extra_params else {}),
@@ -210,6 +205,7 @@ def strobe(reference, inputs, output_dir, lr_type, keep_unmapped, depth_window, 
 
     workflow.start_text = workflow_info(
         ("Samples:", fastq.count),
+        ("Linked-Read Type:", fastq.lr_type),
         ("Reference:", os.path.basename(reference)),
         ("Output Folder:", os.path.basename(output_dir) + "/")
     )

--- a/harpy/commands/align.py
+++ b/harpy/commands/align.py
@@ -126,7 +126,7 @@ def bwa(reference, inputs, output_dir, depth_window, unlinked, threads, keep_unm
     }
 
     workflow.start_text = workflow_info(
-        ("Samples:", fastq.count),\
+        ("Samples:", fastq.count),
         ("Linked-Read Type:", fastq.lr_type),
         ("Reference:", os.path.basename(reference)),
         ("Output Folder:", os.path.basename(output_dir) + "/")

--- a/harpy/commands/assembly.py
+++ b/harpy/commands/assembly.py
@@ -13,7 +13,7 @@ docstring = {
     "harpy assembly": [
         {
             "name": "Assembly Parameters",
-            "options": ["--bx-tag", "--extra-params", "--kmer-length", "--max-memory", "--organism-type"],
+            "options": ["--extra-params", "--kmer-length", "--max-memory", "--organism-type"],
             "panel_styles": {"border_style": "blue"}
         },
         {
@@ -31,13 +31,12 @@ docstring = {
 
 @click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/assembly")
 # SPADES
-@click.option('-b', '--bx-tag', type = click.Choice(['BX', 'BC'], case_sensitive=False), default = "BX", show_default=True, help = "The header tag with the barcode [`BX`,`BC`]")
 @click.option('-k', '--kmer-length', type = KParam(), show_default = True, default = "auto", help = 'K values to use for assembly (`odd` and `<128`)')
 @click.option('-r', '--max-memory',  type = click.IntRange(min = 1000), show_default = True, default = 10000, help = 'Maximum memory for spades to use, in megabytes')
 @click.option('-x', '--extra-params', type = SpadesParams(), help = 'Additional spades parameters, in quotes')
 # TIGMINT/ARCS/LINKS
 @click.option('-y', '--arcs-extra', type = ArcsParams(), help = 'Additional ARCS parameters, in quotes (`option=arg` format)')
-@click.option("-c","--contig-length", type = click.IntRange(min = 10), default = 500, show_default = True, help = "Minimum contig length")
+@click.option("-c", "--contig-length", type = click.IntRange(min = 10), default = 500, show_default = True, help = "Minimum contig length")
 @click.option("-n", "--links", type = click.IntRange(min = 1), default = 5, show_default = True, help = "Minimum number of links to compute scaffold")
 @click.option("-a", "--min-aligned", type = click.IntRange(min = 1), default = 5, show_default = True, help = "Minimum aligned read pairs per barcode")
 @click.option("-q", "--min-quality", type = click.IntRange(0,40, clamp = True), default = 0, show_default = True, help = "Minimum mapping quality")
@@ -76,7 +75,6 @@ def assembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, output_dir, ex
 
     workflow.config = {
         "workflow" : workflow.name,
-        "barcode_tag" : bx_tag.upper(),
         "spades" : {
             "k" : 'auto' if kmer_length == "auto" else ",".join(map(str,kmer_length)),
             "max_memory" : max_memory,

--- a/harpy/commands/assembly.py
+++ b/harpy/commands/assembly.py
@@ -57,7 +57,7 @@ docstring = {
 @click.option('--snakemake', type = SnakemakeParams(), help = 'Additional Snakemake parameters, in quotes')
 @click.argument('fastq_r1', required=True, type=FASTQfile(single=True), nargs=1)
 @click.argument('fastq_r2', required=True, type=FASTQfile(single=True), nargs=1)
-def assembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, output_dir, extra_params,arcs_extra,contig_length,links,min_quality,min_aligned,mismatch,molecule_distance,molecule_length,seq_identity,span, organism_type, container, threads, snakemake, quiet, hpc, setup_only, skip_reports):
+def assembly(fastq_r1, fastq_r2, kmer_length, max_memory, output_dir, extra_params,arcs_extra,contig_length,links,min_quality,min_aligned,mismatch,molecule_distance,molecule_length,seq_identity,span, organism_type, container, threads, snakemake, quiet, hpc, setup_only, skip_reports):
     """
     Assemble linked reads into a genome
 
@@ -71,7 +71,6 @@ def assembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, output_dir, ex
 
     ## checks and validations ##
     fastq = FASTQ([fastq_r1,fastq_r2])
-    fastq.bc_or_bx(bx_tag)
 
     workflow.config = {
         "workflow" : workflow.name,
@@ -107,13 +106,12 @@ def assembly(fastq_r1, fastq_r2, bx_tag, kmer_length, max_memory, output_dir, ex
             "organism_type": organism_type
         },
         "inputs": {
-            "fastq_r1" : fastq_r1,
-            "fastq_r2" : fastq_r2
+            "fastq_r1" : fastq.files[0],
+            "fastq_r2" : fastq.files[1]
         }
     }
 
     workflow.start_text = workflow_info(
-        ("Barcode Tag: ", bx_tag.upper()),
         ("Kmer Length: ", "auto") if kmer_length == "auto" else ("Kmer Length: ", ",".join(map(str,kmer_length))),
         ("Output Folder:", f"{output_dir}/")
     )

--- a/harpy/commands/convert.py
+++ b/harpy/commands/convert.py
@@ -58,7 +58,7 @@ def fastq(target,fq1,fq2,output,barcodes, quiet):
     from_ = which_linkedread(fq1)
     if from_ == "none" and not barcodes:
         print_error("missing barcodes file", "The input data was inferred to be 10X format because neither haplotagging, stlfr, nor tellseq barcodes were detected in their appropriate locations in the first 100 fastq records of the forward reads. A [green]--barcodes[/] file must be provided if the input data is 10x. If the input data is not 10X, then it is formatted incorrectly for whatever technology it was generated with.")
-    if from_ and barcodes:
+    if from_ != "none" and barcodes:
         print_error("unsupported process", f"The input data was inferred to be {from_} format, but a [green]--barcodes[/] file was provided, suggesting it's 10X format data. If the input data is not {from_}, then it is formatted incorrectly for whatever technology it was generated with.")
     if from_ == target:
         print_error("identical conversion target", f"The input file was inferred to be[green]{from_}[/], which is identical to the conversion target [green]{target}[/]. The formats must be different from each other. If the input data is not {from_}, then it is formatted incorrectly for whatever technology it was generated with.")

--- a/harpy/commands/convert.py
+++ b/harpy/commands/convert.py
@@ -56,7 +56,7 @@ def fastq(target,fq1,fq2,output,barcodes, quiet):
     | tellseq      | `:ATCG` format appended to the sequence ID         | `@SEQID:GGCAAATATCGAGAAGTC` |
     """
     from_ = which_linkedread(fq1)
-    if not from_ and not barcodes:
+    if from_ == "none" and not barcodes:
         print_error("missing barcodes file", "The input data was inferred to be 10X format because neither haplotagging, stlfr, nor tellseq barcodes were detected in their appropriate locations in the first 100 fastq records of the forward reads. A [green]--barcodes[/] file must be provided if the input data is 10x. If the input data is not 10X, then it is formatted incorrectly for whatever technology it was generated with.")
     if from_ and barcodes:
         print_error("unsupported process", f"The input data was inferred to be {from_} format, but a [green]--barcodes[/] file was provided, suggesting it's 10X format data. If the input data is not {from_}, then it is formatted incorrectly for whatever technology it was generated with.")

--- a/harpy/commands/downsample.py
+++ b/harpy/commands/downsample.py
@@ -77,7 +77,7 @@ def downsample(input, invalid, output_dir, prefix, barcode_tag, downsample, rand
         "workflow": workflow.name,
         "prefix" :  prefix,
         "linkedreads" : {
-            "barcode-tag" : barcode_tag.upper()
+            "barcode_tag" : barcode_tag.upper()
         },
         "downsample" :  int(downsample) if downsample >= 1 else downsample,
         "invalid_proportion" : invalid,       

--- a/harpy/commands/downsample.py
+++ b/harpy/commands/downsample.py
@@ -76,8 +76,10 @@ def downsample(input, invalid, output_dir, prefix, barcode_tag, downsample, rand
     workflow.config = {
         "workflow": workflow.name,
         "prefix" :  prefix,
+        "linkedreads" : {
+            "barcode-tag" : barcode_tag.upper()
+        },
         "downsample" :  int(downsample) if downsample >= 1 else downsample,
-        "barcode-tag" : barcode_tag.upper(),
         "invalid_proportion" : invalid,       
         **({"random_seed" : random_seed} if random_seed else {}),
         "snakemake" : {

--- a/harpy/commands/validate.py
+++ b/harpy/commands/validate.py
@@ -23,22 +23,12 @@ def validate():
 docstring = {
     "harpy validate bam": [
         {
-            "name": "Parameters",
-            "options": ["--lr-type"],
-            "panel_styles": {"border_style": "blue"}
-        },
-        {
             "name": "Workflow Options",
             "options": ["--container", "--hpc", "--output-dir", "--quiet", "--snakemake", "--threads", "--help"],
             "panel_styles": {"border_style": "dim"}
         },
     ],
     "harpy validate fastq": [
-        {
-            "name": "Parameters",
-            "options": ["--lr-type"],
-            "panel_styles": {"border_style": "blue"}
-        },
         {
             "name": "Workflow Options",
             "options": ["--container", "--hpc", "--output-dir", "--quiet", "--snakemake", "--threads", "--help"],
@@ -48,7 +38,6 @@ docstring = {
 }
 
 @click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/validate/")
-@click.option('-L', '--lr-type', type = click.Choice(['haplotagging', 'stlfr','tellseq'], case_sensitive=False), default = "haplotagging", show_default=True, help = "Linked read type\n[haplotagging, stlfr, tellseq]")
 @click.option('-t', '--threads', default = 4, show_default = True, type = click.IntRange(1, 999, clamp = True), help = 'Number of threads to use')
 @click.option('-o', '--output-dir', type = click.Path(exists = False, resolve_path = True), default = "Validate/bam", show_default=True,  help = 'Output directory name')
 @click.option('--quiet', show_default = True, default = 0, type = click.IntRange(0,2,clamp=True), help = '`0` all output, `1` unified progress bar, `2` no output')
@@ -57,17 +46,17 @@ docstring = {
 @click.option('--container',  is_flag = True, default = False, help = 'Use a container instead of conda', callback=container_ok)
 @click.option('--setup-only',  is_flag = True, hidden = True, default = False, help = 'Setup the workflow and exit')
 @click.argument('inputs', required=True, type=SAMfile(), nargs=-1)
-def bam(inputs, lr_type, output_dir, threads, snakemake, quiet, hpc, container, setup_only):
+def bam(inputs, output_dir, threads, snakemake, quiet, hpc, container, setup_only):
     """
-    Run validity checks on haplotagged BAM files
+    Validate linked-read BAM file format
 
     Provide the input alignment (`.bam`) files and/or directories at the end of the command as individual
     files/folders, using shell wildcards (e.g. `data/betula*.bam`), or both.
     
-    It will check if alignments have BX:Z: tags, that the barcodes are properly formatted for the given
-    `--lr-type` and that the filename matches the `@RG ID` tag.
-    This **will not** fix your data, but it will report the number of records that feature errors  to help
-    you diagnose if file formatting will cause downstream issues. 
+    Validation checks if alignments have BX:Z: tags, that the barcodes are properly formatted for the
+    auto-detected linked-read type, and that the filename matches the `@RG ID` tag. This **will not**
+    fix your data, but it will report the number of records that feature errors to help you diagnose
+    if file formatting will cause downstream issues. 
     """
     workflow = Workflow("validate_bam", "validate_bam.smk", output_dir, quiet)
     workflow.setup_snakemake(container, threads, hpc, snakemake)
@@ -75,22 +64,25 @@ def bam(inputs, lr_type, output_dir, threads, snakemake, quiet, hpc, container, 
     workflow.conda = ["r"]
 
     ## checks and validations ##
-    alignments = SAM(inputs)
+    alignments = SAM(inputs, detect_bc=True, nonlinked_ok = False)
 
     workflow.config = {
         "workflow" : workflow.name,
+        "linkedreads": {
+            "type": alignments.lr_type
+        },
         "snakemake" : {
             "log" : workflow.snakemake_log,
             "absolute": workflow.snakemake_cmd_absolute,
             "relative": workflow.snakemake_cmd_relative,
         },
         "conda_environments" : workflow.conda,
-        "linkedread_type": lr_type.lower(),
         "inputs" : alignments.files
     }
 
     workflow.start_text = workflow_info(
         ("Alignment Files:", alignments.count),
+        ("Barcode Type:", fastq.lr_type),
         ("Output Folder:", os.path.basename(output_dir) + "/")
     )
 
@@ -98,7 +90,6 @@ def bam(inputs, lr_type, output_dir, threads, snakemake, quiet, hpc, container, 
 
 @click.command(no_args_is_help = True, context_settings={"allow_interspersed_args" : False}, epilog = "Documentation: https://pdimens.github.io/harpy/workflows/validate/")
 @click.option('-o', '--output-dir', type = click.Path(exists = False, resolve_path = True), default = "Validate/fastq", show_default=True,  help = 'Output directory name')
-@click.option('-L', '--lr-type', type = click.Choice(['haplotagging', 'stlfr','tellseq'], case_sensitive=False), default = "haplotagging", show_default=True, help = "Linked read type\n[haplotagging, stlfr, tellseq]")
 @click.option('-t', '--threads', default = 4, show_default = True, type = click.IntRange(1, 999, clamp = True), help = 'Number of threads to use')
 @click.option('--container',  is_flag = True, default = False, help = 'Use a container instead of conda', callback=container_ok)
 @click.option('--setup-only',  is_flag = True, hidden = True, default = False, help = 'Setup the workflow and exit')
@@ -106,18 +97,17 @@ def bam(inputs, lr_type, output_dir, threads, snakemake, quiet, hpc, container, 
 @click.option('--quiet', show_default = True, default = 0, type = click.IntRange(0,2,clamp=True), help = '`0` all output, `1` unified progress bar, `2` no output')
 @click.option('--snakemake', type = SnakemakeParams(), help = 'Additional Snakemake parameters, in quotes')
 @click.argument('inputs', required=True, type=FASTQfile(), nargs=-1)
-def fastq(inputs, output_dir, lr_type, threads, snakemake, quiet, hpc, container, setup_only):
+def fastq(inputs, output_dir, threads, snakemake, quiet, hpc, container, setup_only):
     """
-    Run validity checks on haplotagged FASTQ files.
+    Validate linked-read FASTQ file format
 
     Provide the input fastq files and/or directories at the end of the command as 
     individual files/folders, using shell wildcards (e.g. `data/wombat*.fastq.gz`), or both.
     
-    It will check if fastq reads have properly formatted barcodes present in the location and format
-    they are expected to be given `--lr-type` and that the comments in the read headers conform to the
-    SAM specification of `TAG:TYPE:VALUE`. This **will not**
-    fix your data, but it will report the number of reads that feature errors to help
-    you diagnose if file formatting will cause downstream issues. 
+    Validation checks if records in fastq files have properly formatted barcodes for the auto-detected
+    linked-read type, and that any comments in the read headers conform to the SAM specification
+    of `TAG:TYPE:VALUE`. This **will not** fix your data, but it will report the number of reads
+    that feature errors to help you diagnose if file formatting will cause downstream issues. 
     """
     workflow = Workflow("validate_fastq", "validate_fastq.smk", output_dir, quiet)
     workflow.setup_snakemake(container, threads, hpc, snakemake)
@@ -125,25 +115,29 @@ def fastq(inputs, output_dir, lr_type, threads, snakemake, quiet, hpc, container
     workflow.conda = ["r"]
 
     ## checks and validations ##
-    fastq = FASTQ(inputs)
+    fastq = FASTQ(inputs, detect_bc=True, nonlinked_ok=False)
 
     ## setup workflow ##
 
     workflow.config = {
         "workflow" : workflow.name,
+        "linkedreads": {
+            "type": fastq.lr_type
+        },
         "snakemake" : {
             "log" : workflow.snakemake_log,
             "absolute": workflow.snakemake_cmd_absolute,
             "relative": workflow.snakemake_cmd_relative,
         },
         "conda_environments" : workflow.conda,
-        "linkedread_type": lr_type.lower(),
         "inputs" : fastq.files
     }
 
     workflow.start_text = workflow_info(
         ("FASTQ Files:", fastq.count),
-        ("Output Folder:", os.path.basename(output_dir) + "/")
+        ("Linked-Read Type:", fastq.lr_type),
+        ("Output Folder:", os.path.basename(output_dir) + "/"),
+
     )
 
     workflow.initialize(setup_only)

--- a/harpy/commands/validate.py
+++ b/harpy/commands/validate.py
@@ -82,7 +82,7 @@ def bam(inputs, output_dir, threads, snakemake, quiet, hpc, container, setup_onl
 
     workflow.start_text = workflow_info(
         ("Alignment Files:", alignments.count),
-        ("Barcode Type:", fastq.lr_type),
+        ("Barcode Type:", alignments.lr_type),
         ("Output Folder:", os.path.basename(output_dir) + "/")
     )
 

--- a/harpy/common/convert.py
+++ b/harpy/common/convert.py
@@ -22,7 +22,7 @@ class FQRecord():
         self.illumina_new = designation[0] if designation else f"{fr}0:CAGATC"
         self.illumina_old = "/1" if self.forward else "/2"
         self.id = pysamfq.name.rstrip(self.illumina_old)
-        self.comment = "\t".join(i for i in comments if not i.startswith("1:N:"))
+        self.comment = "\t".join(i for i in comments if not i.startswith(fr))
         self.seq = pysamfq.sequence
         self.qual = pysamfq.quality
         self.valid = True

--- a/harpy/common/printing.py
+++ b/harpy/common/printing.py
@@ -77,7 +77,7 @@ def print_setup_error(exitcode: int) -> None:
         errortext = "Something is wrong with the Snakefile for this workflow. If you manually edited the Snakefile, see the error below for troubleshooting. If you didn't, it's probably a bug (oops!) and you should submit an issue on GitHub: [bold]https://github.com/pdimens/harpy/issues"
     else:
         errortype = "Software Environment Error"
-        errortext = "There was an issue creating the software environment necessary to run this workflow. If you manually edited the conda dependencies in [blue]/workflows/envs[/], see the error below for troubleshooting. If you didn't, it might be a bug or related to how your system is setup for Conda or Singularity environments and you should submit an issue on GitHub: [bold]https://github.com/pdimens/harpy/issues"
+        errortext = "There was an issue creating the software environment necessary to run this workflow. If you manually edited the conda dependencies in [blue]/workflows/envs[/], see the error below for troubleshooting. If you didn't, it might be a bug or related to how your system is setup for Conda or Apptainer environments and you should submit an issue on GitHub: [bold]https://github.com/pdimens/harpy/issues"
         # Check if this is the `base` conda environment
         current_env = os.environ.get('CONDA_DEFAULT_ENV')
         if current_env == 'base':

--- a/harpy/snakefiles/align_bwa.smk
+++ b/harpy/snakefiles/align_bwa.smk
@@ -11,9 +11,9 @@ wildcard_constraints:
     sample = r"[a-zA-Z0-9._-]+"
 
 fqlist       = config["inputs"]["fastq"]
-molecule_distance = config["barcodes"]["distance_threshold"]
-ignore_bx = config["barcodes"]["ignore"]
-is_standardized = config["barcodes"]["standard_format"]
+molecule_distance = config["linkedreads"]["distance_threshold"]
+ignore_bx = config["linkedreads"]["type"] == "none"
+is_standardized = config["linkedreads"]["standardized"]
 keep_unmapped = config["keep_unmapped"]
 extra 		= config.get("extra", "") 
 genomefile 	= config["inputs"]["reference"]

--- a/harpy/snakefiles/align_strobe.smk
+++ b/harpy/snakefiles/align_strobe.smk
@@ -18,9 +18,9 @@ if bn.lower().endswith(".gz"):
     bn = bn[:-3]
 workflow_geno = f"workflow/reference/{bn}"
 windowsize  = config["depth_windowsize"]
-molecule_distance = config["barcodes"]["distance_threshold"]
-ignore_bx = config["barcodes"]["ignore"]
-is_standardized = config["barcodes"]["standard_format"]
+molecule_distance = config["linkedreads"]["distance_threshold"]
+ignore_bx = config["linkedreads"]["type"] == "none"
+is_standardized = config["linkedreads"]["standardized"]
 keep_unmapped = config["keep_unmapped"]
 skip_reports = config["reports"]["skip"]
 plot_contigs = config["reports"]["plot_contigs"]    

--- a/harpy/snakefiles/downsample.smk
+++ b/harpy/snakefiles/downsample.smk
@@ -107,7 +107,7 @@ rule workflow_summary:
         if is_fastq:
             summary.append(convs)
         extraction = "Barcodes were extracted and sampled using:\n"
-        extraction += f"\textract_bxtags -i {invalids} -b BX -d {downsample} {params.random_seed} input.bam"
+        extraction += f"\textract_bxtags -i {invalids} -b {bc_tag} -d {downsample} {params.random_seed} input.bam"
         summary.append(extraction)
         downsampled = "The inputs were indexed and downsampled using:\n"
         downsampled += f"\tsamtools view -O BAM -h -D {bc_tag}:barcodes.txt input.bam"

--- a/harpy/snakefiles/downsample.smk
+++ b/harpy/snakefiles/downsample.smk
@@ -12,7 +12,7 @@ inputs      = config["inputs"]
 invalids    = config["invalid_proportion"]
 random_seed = config.get("random_seed", None)
 downsample  = config["downsample"]
-bc_tag      = config["barcode-tag"]
+bc_tag      = config["linkedreads"]["barcode-tag"]
 prefix      = config["prefix"]
 infiles     = dict(zip(inputs, inputs))
 is_fastq    = True if len(inputs) == 2 else False

--- a/harpy/snakefiles/downsample.smk
+++ b/harpy/snakefiles/downsample.smk
@@ -12,7 +12,7 @@ inputs      = config["inputs"]
 invalids    = config["invalid_proportion"]
 random_seed = config.get("random_seed", None)
 downsample  = config["downsample"]
-bc_tag      = config["linkedreads"]["barcode-tag"]
+bc_tag      = config["linkedreads"]["barcode_tag"]
 prefix      = config["prefix"]
 infiles     = dict(zip(inputs, inputs))
 is_fastq    = True if len(inputs) == 2 else False

--- a/harpy/snakefiles/metassembly.smk
+++ b/harpy/snakefiles/metassembly.smk
@@ -9,7 +9,7 @@ onstart:
 
 FQ1 = config["inputs"]["fastq_r1"]
 FQ2 = config["inputs"]["fastq_r2"]
-BX_TAG = config["barcode_tag"].upper()
+BX_TAG = config["linkedreads"]["barcode_tag"]
 max_mem = config["spades"]["max_memory"]
 k_param = config["spades"]["k"]
 ignore_bx = config["spades"]["ignore_barcodes"]

--- a/harpy/snakefiles/phase.smk
+++ b/harpy/snakefiles/phase.smk
@@ -25,7 +25,8 @@ bamlist           = config["inputs"]["alignments"]
 bamdict           = dict(zip(bamlist, bamlist))
 invalid_regex = {
     "haplotagging" : "'$4 !~ /[ABCD]00/'",
-    "stlfr" : "'$4 !~ /^0_|_0_|_0$/'"
+    "stlfr" : "'$4 !~ /^0_|_0_|_0$/'",
+    "tellseq": "'$4 !~ /N/'"
 }
 if bc_type == "none":
     fragfile = "extract_hairs/{sample}.unlinked.frags"

--- a/harpy/snakefiles/phase.smk
+++ b/harpy/snakefiles/phase.smk
@@ -11,26 +11,22 @@ onstart:
 wildcard_constraints:
     sample = r"[a-zA-Z0-9._-]+"
 
-bc_type = config["barcodes"]["linkedread_type"]
-
-if bc_type == "haplotagging":
-    invalid_bc = "'$4 !~ /[ABCD]00/'"
-elif bc_type == "stlfr":
-    invalid_bc = "'$4 !~ /^0_|_0_|_0$/'"
-else:
-    invalid_bc = "'$4 !~ /N/'"
-
+bc_type           = config["linkedreads"]["type"]
 pruning           = config["phasing"]["prune"]
 map_qual          = config["phasing"]["min_map_quality"]
 base_qual         = config["phasing"]["min_base_quality"]
-molecule_distance = config["barcodes"]["distance_threshold"]
+molecule_distance = config["linkedreads"]["distance_threshold"]
 extra             = config.get("extra", "") 
 samples_from_vcf  = config["inputs"]["vcf"]["prioritize_samples"]
 variantfile       = config["inputs"]["vcf"]["file"]
 skip_reports      = config["reports"]["skip"]
 plot_contigs      = config["reports"]["plot_contigs"]
-bamlist     = config["inputs"]["alignments"]
-bamdict     = dict(zip(bamlist, bamlist))
+bamlist           = config["inputs"]["alignments"]
+bamdict           = dict(zip(bamlist, bamlist))
+invalid_regex = {
+    "haplotagging" : "'$4 !~ /[ABCD]00/'",
+    "stlfr" : "'$4 !~ /^0_|_0_|_0$/'"
+}
 if bc_type == "none":
     fragfile = "extract_hairs/{sample}.unlinked.frags"
     linkarg = "--10x 0"
@@ -136,7 +132,7 @@ rule extract_hairs:
         "logs/extract_hairs/{sample}.unlinked.log"
     params:
         static = f"{indelarg} {linkarg} --mmq {map_qual} --mbq {base_qual} --nf 1 --maxfragments 1500000",
-        purge_invalid = invalid_bc
+        purge_invalid = invalid_regex.get(bc_type, "'$4 !~ /N/'")
     conda:
         "envs/phase.yaml"
     shell:
@@ -304,7 +300,8 @@ rule workflow_summary:
         phase = "Phasing was performed using the components of HapCut2:\n"
         phase += f"\textractHAIRS {linkarg} --nf 1 --maxfragments 1000000 --bam sample.bam --VCF sample.vcf --out sample.unlinked.frags\n"
         if bc_type != "none":
-            phase += f"\tLinkFragments.py --bam sample.bam --VCF sample.vcf --fragments sample.unlinked.frags --out sample.linked.frags -d {molecule_distance}\n"
+            phase += f"\t awk " + invalid_regex.get(bc_type, "'$4 !~ /N/'") + " sample.unlinked.frags > sample.frags.filt"
+            phase += f"\tLinkFragments.py --bam sample.bam --VCF sample.vcf --fragments sample.frags.filt --out sample.linked.frags -d {molecule_distance}\n"
             phase += f"\tHAPCUT2 --fragments sample.linked.frags --vcf sample.vcf --out sample.blocks --nf 1 --error_analysis_mode 1 --call_homozygous 1 --outvcf 1 {params.prune} {params.extra}\n"
         else:
             phase += f"\tHAPCUT2 --fragments sample.unlinked.frags --vcf sample.vcf --out sample.blocks --nf 1 --error_analysis_mode 1 --call_homozygous 1 --outvcf 1 {params.prune} {params.extra}\n"

--- a/harpy/snakefiles/qc.smk
+++ b/harpy/snakefiles/qc.smk
@@ -10,14 +10,13 @@ onstart:
 wildcard_constraints:
     sample = r"[a-zA-Z0-9._-]+"
 
-fqlist       = config["inputs"]
-min_len 	 = config["min_len"]
-max_len 	 = config["max_len"]
-extra 	     = config.get("extra", "") 
-lr_type    = config["linkedread_type"]
-ignore_bx = lr_type == "none"
+fqlist        = config["inputs"]
+min_len 	  = config["min_len"]
+max_len 	  = config["max_len"]
+extra 	      = config.get("extra", "") 
+lr_type       = config["linkedreads"]["type"]
 trim_adapters = config.get("trim_adapters", None)
-dedup        = config["deduplicate"]
+dedup         = config["deduplicate"]
 skip_reports  = config["reports"]["skip"]
 bn_r = r"([_\.][12]|[_\.][FR]|[_\.]R[12](?:\_00[0-9])*)?\.((fastq|fq)(\.gz)?)$"
 samplenames = {re.sub(bn_r, "", os.path.basename(i), flags = re.IGNORECASE) for i in fqlist}
@@ -133,7 +132,7 @@ rule workflow_summary:
     default_target: True
     input:
         fq = collect("{sample}.{FR}.fq.gz", FR = ["R1", "R2"], sample = samplenames),
-        bx_report = "reports/barcode.summary.html" if not skip_reports and not ignore_bx else [],
+        bx_report = "reports/barcode.summary.html" if not skip_reports and lr_type != "none" else [],
         agg_report = "reports/qc.report.html" if not skip_reports else []    
     params:
         minlen = f"--length_required {min_len}",

--- a/harpy/snakefiles/validate_bam.smk
+++ b/harpy/snakefiles/validate_bam.smk
@@ -11,7 +11,7 @@ onstart:
 wildcard_constraints:
     sample = r"[a-zA-Z0-9._-]+"
 
-lr_platform = config["linkedread_type"]
+lr_platform = config["linkedreads"]["type"]
 bamlist = config["inputs"]
 bamdict = dict(zip(bamlist, bamlist))
 samplenames = {Path(i).stem for i in bamlist}

--- a/harpy/snakefiles/validate_fastq.smk
+++ b/harpy/snakefiles/validate_fastq.smk
@@ -10,7 +10,7 @@ onstart:
 wildcard_constraints:
     sample = r"[a-zA-Z0-9._-]+"
 
-lr_platform = config["linkedread_type"]
+lr_platform = config["linkedreads"]["type"]
 fqlist = config["inputs"]
 bn_r = r"([_\.][12]|[_\.][FR]|[_\.]R[12](?:\_00[0-9])*)?\.((fastq|fq)(\.gz)?)$"
 samplenames = {re.sub(bn_r, "", os.path.basename(i), flags = re.IGNORECASE) for i in fqlist}

--- a/harpy/validation/barcodes.py
+++ b/harpy/validation/barcodes.py
@@ -63,9 +63,8 @@ def which_linkedread(fastq: str) -> str:
     haplotagging = re.compile(r'\s?BX:Z:(A[0-9]{2}C[0-9]{2}B[0-9]{2}D[0-9]{2})')
     stlfr = re.compile(r'#([0-9]+_[0-9]+_[0-9]+)(\s|$)')
     tellseq = re.compile(r':([ATCGN]+)(\s|$)')
-    recs = 1
     with pysam.FastxFile(fastq, persist=False) as fq:
-        for i in fq:
+        for recs,i in enumerate(fq, 1):
             if recs > 100:
                 break
             if i.comment and haplotagging.search(i.comment):
@@ -74,7 +73,6 @@ def which_linkedread(fastq: str) -> str:
                 return "stlfr"
             elif tellseq.search(i.name):
                 return "tellseq"
-            recs += 1
     return "none"
 
 def which_linkedread_sam(file_path: str) -> str:

--- a/harpy/validation/barcodes.py
+++ b/harpy/validation/barcodes.py
@@ -76,9 +76,9 @@ def which_linkedread(fastq: str) -> str:
                 return "tellseq"
     return "none"
 
-HAPLOTAGGING_RX_SAM = r"^A\d{2}C\d{2}B\d{2}D\d{2}$"
-STLFR_RX_SAM = r"^\d+_\d+_\d+$"
-TELLSEQ_RX_SAM = r"^[ATCGN]+$"
+HAPLOTAGGING_RX_SAM = re.compile(r"^A\d{2}C\d{2}B\d{2}D\d{2}$")
+STLFR_RX_SAM = re.compile(r"^\d+_\d+_\d+$")
+TELLSEQ_RX_SAM = re.compile(r"^[ATCGN]+$")
 
 def which_linkedread_sam(file_path: str) -> str:
     """

--- a/harpy/validation/barcodes.py
+++ b/harpy/validation/barcodes.py
@@ -55,10 +55,10 @@ def validate_barcodefile(infile: str, return_len: bool = False, quiet: int = 0, 
     if return_len:
         return lengths.pop()
 
-def which_linkedread(fastq: str) -> str|None:
+def which_linkedread(fastq: str) -> str:
     """
     Scans the first 100 records of a FASTQ file and tries to determine the barcode technology
-    Returns one of: "haplotagging", "stlfr", "tellseq" or None
+    Returns one of: "haplotagging", "stlfr", "tellseq", or "none"
     """
     haplotagging = re.compile(r'\s?BX:Z:(A[0-9]{2}C[0-9]{2}B[0-9]{2}D[0-9]{2})')
     stlfr = re.compile(r'#([0-9]+_[0-9]+_[0-9]+)(\s|$)')
@@ -75,11 +75,12 @@ def which_linkedread(fastq: str) -> str|None:
             elif tellseq.search(i.name):
                 return "tellseq"
             recs += 1
+    return "none"
 
-def which_linkedread_sam(file_path: str) -> str|None:
+def which_linkedread_sam(file_path: str) -> str:
     """
     Scans the first 100 records of a SAM/BAM file and tries to determine the barcode technology
-    Returns one of: "haplotagging", "stlfr", "tellseq" or None
+    Returns one of: "haplotagging", "stlfr", "tellseq", or "none"
     """
     recs = 1
     with pysam.AlignmentFile(file_path, require_index=False) as alnfile:
@@ -100,5 +101,5 @@ def which_linkedread_sam(file_path: str) -> str|None:
             except KeyError:
                 recs += 1
                 continue
-    return None
+    return "none"
 

--- a/harpy/validation/fastq.py
+++ b/harpy/validation/fastq.py
@@ -61,7 +61,7 @@ class FASTQ():
         self.count = len({re.sub(bn_r, "", i, flags = re.IGNORECASE) for i in uniqs})
 
         if detect_bc:
-            for i in range(min(6, self.count), 2):
+            for i in range(0, min(6, self.count), 2):
                 self.lr_type = which_linkedread(self.files[i])
                 if self.lr_type != "none":
                     break
@@ -72,8 +72,6 @@ class FASTQ():
                     "This command requires linked-read data, but harpy was unable to associate the input data as being haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 lines of the first 5 files and failed to find barcodes conforming to those formatting standards.",
                     "Please double-check that these data are indeed linked-read data and the barcodes are formatted according to that technology standard."
                 )
-
-
 
     def has_bx_tag(self, max_records: int = 50):
         """
@@ -90,6 +88,7 @@ class FASTQ():
                         return
                     if records >= max_records:
                         break
+
     def bc_or_bx(self, tag: str, max_records: int = 50) -> None:
         """
         Parse the first 50 records of a list of fastq files to verify that they have BX/BC tag, and only one of those two types per file

--- a/harpy/validation/fastq.py
+++ b/harpy/validation/fastq.py
@@ -61,8 +61,13 @@ class FASTQ():
         self.count = len({re.sub(bn_r, "", i, flags = re.IGNORECASE) for i in uniqs})
 
         if detect_bc:
-            for i in range(0, min(6, self.count), 2):
-                self.lr_type = which_linkedread(self.files[i])
+            for i,fq in enumerate(self.files, 1):
+                if i > 10:
+                    break
+                # skip the reverse-reads file
+                if i % 2 == 0:
+                    continue
+                self.lr_type = which_linkedread(fq)
                 if self.lr_type != "none":
                     break
             self.bx_tag = self.lr_type == "haplotagging"

--- a/harpy/validation/fastq.py
+++ b/harpy/validation/fastq.py
@@ -87,15 +87,13 @@ class FASTQ():
         If a BX:Z: tag is present, updates self.bx_tag to True
         """
         for i in self.files:
-            records = 0
             with pysam.FastxFile(i, persist=False) as fq:
-                for record in fq:
-                    records += 1
+                for i,record in enumerate(fq, 1):
+                    if i > max_records:
+                        break
                     if "BX:Z" in record.comment:
                         self.bx_tag = True
                         return
-                    if records >= max_records:
-                        break
 
     def bc_or_bx(self, tag: str, max_records: int = 50) -> None:
         """
@@ -106,10 +104,10 @@ class FASTQ():
         for fastq in self.files:
             PRIMARY = False
             SECONDARY = False
-            records = 0
             with pysam.FastxFile(fastq, persist=False) as fq:
-                for record in fq:
-                    records += 1
+                for i,record in enumerate(fq, 1):
+                    if i > max_records:
+                        break
                     PRIMARY = True if primary in record.comment else PRIMARY
                     SECONDARY = True if secondary in record.comment else SECONDARY
                     if PRIMARY and SECONDARY:
@@ -118,8 +116,6 @@ class FASTQ():
                             f"Both [green bold]BC:Z[/] and [green bold]BX:Z[/] tags were detected in the read headers for [blue]{os.path.basename(fastq)}[/]. Athena accepts [bold]only[/] one of [green bold]BC:Z[/] or [green bold]BX:Z[/].",
                             "Check why your data has both tags in use and remove/rename one of the tags."
                         )
-                    if records >= max_records:
-                        break
                 # check for one or the other after parsing is done
                 errtext = f" However, [green]{secondary}:Z[/] tags were detected, perhaps you meant those?" if SECONDARY else ""
                 if not PRIMARY:

--- a/harpy/validation/fastq.py
+++ b/harpy/validation/fastq.py
@@ -41,7 +41,7 @@ class FASTQ():
             print_error(
                 "invalid characters",
                 "Invalid characters were detected in the input FASTQ file names.",
-                "Valid file names may contain only:\n  - [green]A-Z[/] characters (case insensitive)\n  - [green].[/] (period)\n  - [green]_[/] (underscore)\n  - [green]-[/] (dash)",
+                "Valid file names may contain only:\n  - [green]A-Z 0-9[/] characters (case insensitive)\n  - [green].[/] (period)\n  - [green]_[/] (underscore)\n  - [green]-[/] (dash)",
                 "The offending files",
                 ", ".join(badmatch)
                 )
@@ -91,7 +91,8 @@ class FASTQ():
                 for i,record in enumerate(fq, 1):
                     if i > max_records:
                         break
-                    if "BX:Z" in record.comment:
+                    cmt = record.comment or ""
+                    if "BX:Z" in cmt:
                         self.bx_tag = True
                         return
 

--- a/harpy/validation/fastq.py
+++ b/harpy/validation/fastq.py
@@ -10,7 +10,7 @@ class FASTQ():
     '''
     A class to contain and validate FASTQ input files. If detect_bc is True, will scan the first 100
     records of the first [up to] 5 forward-read files to determine barcode type, stopping at the first
-    detection of a recognizable barcode technology and occupies the FASTQ.lr_type field with one of
+    detection of a recognizable barcode technology and sets the FASTQ.lr_type field with one of
     ["none", "haplotagging", "stlfr", "tellseq"]. The nonlinked_ok option controls whether
     the detection of "none" linked-read types is permissible, otherwise throwing an error.
     '''
@@ -75,7 +75,7 @@ class FASTQ():
             if not nonlinked_ok and self.lr_type == "none":
                 print_error(
                     "incompatible data",
-                    "This command requires linked-read data, but harpy was unable to associate the input data as being haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 lines of up to the first 5 files and failed to find barcodes conforming to those formatting standards.",
+                    "This command requires linked-read data, but harpy was unable to associate the input data as being haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 records of up to the first 5 files and failed to find barcodes conforming to those formatting standards.",
                     "Please double-check that these data are indeed linked-read data and the barcodes are formatted according to that technology standard.",
                     "Files Scanned",
                     "\n".join(scanned)
@@ -119,7 +119,7 @@ class FASTQ():
                             "Check why your data has both tags in use and remove/rename one of the tags."
                         )
                 # check for one or the other after parsing is done
-                errtext = f" However, [green]{secondary}:Z[/] tags were detected, perhaps you meant those?" if SECONDARY else ""
+                errtext = f" However, [green]{secondary}[/] tags were detected, perhaps you meant those?" if SECONDARY else ""
                 if not PRIMARY:
                     print_error(
                         "no barcodes found",

--- a/harpy/validation/fastq.py
+++ b/harpy/validation/fastq.py
@@ -42,7 +42,7 @@ class FASTQ():
                 "invalid characters",
                 "Invalid characters were detected in the input FASTQ file names.",
                 "Valid file names may contain only:\n  - [green]A-Z 0-9[/] characters (case insensitive)\n  - [green].[/] (period)\n  - [green]_[/] (underscore)\n  - [green]-[/] (dash)",
-                "The offending files",
+                "Offending Files",
                 ", ".join(badmatch)
                 )
         if dupes:
@@ -53,7 +53,7 @@ class FASTQ():
                 "clashing sample names",
                 "Identical sample names were detected in the inputs, which will cause unexpected behavior and results.\n  - files with identical names but different-cased extensions are treated as identical\n  - files with the same name from different directories are also considered identical",
                 "Make sure all input files have unique names.",
-                "Files with clashing names",
+                "Files with Clashing Names",
                 dupe_out
             )
         
@@ -77,7 +77,7 @@ class FASTQ():
                     "incompatible data",
                     "This command requires linked-read data, but harpy was unable to associate the input data as being haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 lines of the first 5 files and failed to find barcodes conforming to those formatting standards.",
                     "Please double-check that these data are indeed linked-read data and the barcodes are formatted according to that technology standard.",
-                    "Files scanned",
+                    "Files Scanned",
                     "\n".join(scanned)
                 )
 

--- a/harpy/validation/fastq.py
+++ b/harpy/validation/fastq.py
@@ -75,7 +75,7 @@ class FASTQ():
             if not nonlinked_ok and self.lr_type == "none":
                 print_error(
                     "incompatible data",
-                    "This command requires linked-read data, but harpy was unable to associate the input data as being haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 lines of the first 5 files and failed to find barcodes conforming to those formatting standards.",
+                    "This command requires linked-read data, but harpy was unable to associate the input data as being haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 lines of up to the first 5 files and failed to find barcodes conforming to those formatting standards.",
                     "Please double-check that these data are indeed linked-read data and the barcodes are formatted according to that technology standard.",
                     "Files Scanned",
                     "\n".join(scanned)

--- a/harpy/validation/fastq.py
+++ b/harpy/validation/fastq.py
@@ -108,8 +108,9 @@ class FASTQ():
                 for i,record in enumerate(fq, 1):
                     if i > max_records:
                         break
-                    PRIMARY = True if primary in record.comment else PRIMARY
-                    SECONDARY = True if secondary in record.comment else SECONDARY
+                    cmt = record.comment or ""
+                    PRIMARY = (primary in cmt) or PRIMARY
+                    SECONDARY = (secondary in cmt) or SECONDARY
                     if PRIMARY and SECONDARY:
                         print_error(
                             "clashing barcode tags",

--- a/harpy/validation/fastq.py
+++ b/harpy/validation/fastq.py
@@ -3,7 +3,6 @@ from itertools import chain
 import os
 import re
 import pysam
-from rich.markdown import Markdown
 from harpy.common.printing import print_error
 from harpy.validation.barcodes import which_linkedread
 
@@ -42,7 +41,7 @@ class FASTQ():
             print_error(
                 "invalid characters",
                 "Invalid characters were detected in the input FASTQ file names.",
-                Markdown("Valid file names may contain only:\n- **A-Z** characters (case insensitive)\n- **.** (period)\n- **_** (underscore)\n- **-** (dash)"),
+                "Valid file names may contain only:\n  - [green]A-Z[/] characters (case insensitive)\n  - [green].[/] (period)\n  - [green]_[/] (underscore)\n  - [green]-[/] (dash)",
                 "The offending files",
                 ", ".join(badmatch)
                 )
@@ -52,7 +51,7 @@ class FASTQ():
                 dupe_out.append(" ".join([j for j in self.files if i in j]))
             print_error(
                 "clashing sample names",
-                Markdown("Identical sample names were detected in the inputs, which will cause unexpected behavior and results.\n- files with identical names but different-cased extensions are treated as identical\n- files with the same name from different directories are also considered identical"),
+                "Identical sample names were detected in the inputs, which will cause unexpected behavior and results.\n  - files with identical names but different-cased extensions are treated as identical\n  - files with the same name from different directories are also considered identical",
                 "Make sure all input files have unique names.",
                 "Files with clashing names",
                 dupe_out
@@ -61,12 +60,14 @@ class FASTQ():
         self.count = len({re.sub(bn_r, "", i, flags = re.IGNORECASE) for i in uniqs})
 
         if detect_bc:
+            scanned = []
             for i,fq in enumerate(self.files, 1):
                 if i > 10:
                     break
                 # skip the reverse-reads file
                 if i % 2 == 0:
                     continue
+                scanned.append(os.path.basename(fq))
                 self.lr_type = which_linkedread(fq)
                 if self.lr_type != "none":
                     break
@@ -75,7 +76,9 @@ class FASTQ():
                 print_error(
                     "incompatible data",
                     "This command requires linked-read data, but harpy was unable to associate the input data as being haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 lines of the first 5 files and failed to find barcodes conforming to those formatting standards.",
-                    "Please double-check that these data are indeed linked-read data and the barcodes are formatted according to that technology standard."
+                    "Please double-check that these data are indeed linked-read data and the barcodes are formatted according to that technology standard.",
+                    "Files scanned",
+                    "\n".join(scanned)
                 )
 
     def has_bx_tag(self, max_records: int = 50):

--- a/harpy/validation/fastq.py
+++ b/harpy/validation/fastq.py
@@ -61,8 +61,8 @@ class FASTQ():
         self.count = len({re.sub(bn_r, "", i, flags = re.IGNORECASE) for i in uniqs})
 
         if detect_bc:
-            for i in range(min(6, self.count)):
-                self.lr_type = which_linkedread(self.files[0])
+            for i in range(min(6, self.count), 2):
+                self.lr_type = which_linkedread(self.files[i])
                 if self.lr_type != "none":
                     break
             self.bx_tag = self.lr_type == "haplotagging"

--- a/harpy/validation/fastq.py
+++ b/harpy/validation/fastq.py
@@ -10,8 +10,8 @@ from harpy.validation.barcodes import which_linkedread
 class FASTQ():
     '''
     A class to contain and validate FASTQ input files. If detect_bc is True, will scan the first 100
-    records of the first 5 files to determine barcode type, stoping at the first detection of a
-    recognizable barcode technology and occupies the SAM.lr_type field with one of
+    records of the first [up to] 5 forward-read files to determine barcode type, stopping at the first
+    detection of a recognizable barcode technology and occupies the FASTQ.lr_type field with one of
     ["none", "haplotagging", "stlfr", "tellseq"]. The nonlinked_ok option controls whether
     the detection of "none" linked-read types is permissible, otherwise throwing an error.
     '''

--- a/harpy/validation/sam.py
+++ b/harpy/validation/sam.py
@@ -41,7 +41,7 @@ class SAM():
                 "invalid characters",
                 "Invalid characters were detected in the input file names.",
                 "Valid file names may contain only:\n  - [green]A-Z 0-9[/] characters (case insensitive)\n  - [green].[/] (period)\n  - [green]_[/] (underscore)\n  - [green]-[/] (dash)",
-                "Offending files",
+                "Offending Files",
                 ", ".join(badmatch)
                 )
         if dupes:
@@ -67,7 +67,7 @@ class SAM():
             if not nonlinked_ok and self.lr_type == "none":
                 print_error(
                     "incompatible data",
-                    "This command requires linked-read data, but harpy was unable to associate the input data as being haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 lines of the first 5 files and failed to find barcodes conforming to those formatting standards.",
+                    "This command requires linked-read data, but harpy was unable to associate the input data as being haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 lines of up to the first 5 files and failed to find barcodes conforming to those formatting standards.",
                     "Please double-check that these data are indeed linked-read data and the barcodes are formatted according to that technology standard.",
                     "Files Scanned",
                     "\n".join(scanned)

--- a/harpy/validation/sam.py
+++ b/harpy/validation/sam.py
@@ -41,7 +41,7 @@ class SAM():
                 "invalid characters",
                 "Invalid characters were detected in the input file names.",
                 "Valid file names may contain only:\n  - [green]A-Z 0-9[/] characters (case insensitive)\n  - [green].[/] (period)\n  - [green]_[/] (underscore)\n  - [green]-[/] (dash)",
-                "The offending files",
+                "Offending files",
                 ", ".join(badmatch)
                 )
         if dupes:
@@ -52,7 +52,7 @@ class SAM():
                 "clashing sample names",
                 "Identical filenames were detected, which will cause unexpected behavior and results.\n  - files with identical names but different-cased extensions are treated as identical\n  - files with the same name from different directories are also considered identical",
                 "Make sure all input files have unique names.",
-                "Files with clashing names",
+                "Files with Clashing Names",
                 dupe_out
             )
         if detect_bc:
@@ -69,6 +69,6 @@ class SAM():
                     "incompatible data",
                     "This command requires linked-read data, but harpy was unable to associate the input data as being haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 lines of the first 5 files and failed to find barcodes conforming to those formatting standards.",
                     "Please double-check that these data are indeed linked-read data and the barcodes are formatted according to that technology standard.",
-                    "Files scanned",
+                    "Files Scanned",
                     "\n".join(scanned)
                 )

--- a/harpy/validation/sam.py
+++ b/harpy/validation/sam.py
@@ -9,7 +9,7 @@ from harpy.validation.barcodes import which_linkedread_sam
 class SAM():
     """
     A class to contain and validate SAM input files. If detect_bc is True, will scan the first 100
-    records of the first 5 files to determine barcode type, stoping at the first detection of a
+    records of the first [up to] 5 files to determine barcode type, stopping at the first detection of a
     recognizable barcode technology and occupies the SAM.lr_type field with one of
     ["none", "haplotagging", "stlfr", "tellseq"]. The nonlinked_ok option controls whether
     the detection of "none" linked-read types is permissible, otherwise throwing an error.
@@ -64,6 +64,6 @@ class SAM():
             if not nonlinked_ok and self.lr_type == "none":
                 print_error(
                     "incompatible data",
-                    "This command requires linked-read data, but harpy was unable to associate the input data as being 10X, haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 lines of the first 5 files and failed to find barcodes conforming to those formatting standards.",
+                    "This command requires linked-read data, but harpy was unable to associate the input data as being haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 lines of the first 5 files and failed to find barcodes conforming to those formatting standards.",
                     "Please double-check that these data are indeed linked-read data and the barcodes are formatted according to that technology standard."
                 )

--- a/harpy/validation/sam.py
+++ b/harpy/validation/sam.py
@@ -4,17 +4,23 @@ import os
 import re
 from rich.markdown import Markdown
 from harpy.common.printing import print_error
+from harpy.validation.barcodes import which_linkedread_sam
 
 class SAM():
-    '''
-    A class to contain and validate SAM input files.
-    '''
-    def __init__(self, filenames):
+    """
+    A class to contain and validate SAM input files. If detect_bc is True, will scan the first 100
+    records of the first 5 files to determine barcode type, stoping at the first detection of a
+    recognizable barcode technology and occupies the SAM.lr_type field with one of
+    ["none", "haplotagging", "stlfr", "tellseq"]. The nonlinked_ok option controls whether
+    the detection of "none" linked-read types is permissible, otherwise throwing an error.
+    """
+    def __init__(self, filenames, detect_bc:bool = False, nonlinked_ok:bool = True):
         if any(isinstance(i, list) for i in filenames):
             self.files = list(chain.from_iterable(filenames))
         else:
             self.files = filenames
         self.count = 0
+        self.lr_type = "none"
 
         re_ext = re.compile(r"\.(bam|sam)$", re.IGNORECASE)
         uniqs = set()
@@ -50,4 +56,14 @@ class SAM():
                 "Files with clashing names",
                 dupe_out
             )
-
+        if detect_bc:
+            for i in range(min(6, self.count)):
+                self.lr_type = which_linkedread_sam(self.files[0])
+                if self.lr_type != "none":
+                    break
+            if not nonlinked_ok and self.lr_type == "none":
+                print_error(
+                    "incompatible data",
+                    "This command requires linked-read data, but harpy was unable to associate the input data as being 10X, haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 lines of the first 5 files and failed to find barcodes conforming to those formatting standards.",
+                    "Please double-check that these data are indeed linked-read data and the barcodes are formatted according to that technology standard."
+                )

--- a/harpy/validation/sam.py
+++ b/harpy/validation/sam.py
@@ -58,7 +58,7 @@ class SAM():
             )
         if detect_bc:
             for i in range(min(6, self.count)):
-                self.lr_type = which_linkedread_sam(self.files[0])
+                self.lr_type = which_linkedread_sam(self.files[i])
                 if self.lr_type != "none":
                     break
             if not nonlinked_ok and self.lr_type == "none":

--- a/harpy/validation/sam.py
+++ b/harpy/validation/sam.py
@@ -9,7 +9,7 @@ class SAM():
     """
     A class to contain and validate SAM input files. If detect_bc is True, will scan the first 100
     records of the first [up to] 5 files to determine barcode type, stopping at the first detection of a
-    recognizable barcode technology and occupies the SAM.lr_type field with one of
+    recognizable barcode technology and sets the SAM.lr_type field with one of
     ["none", "haplotagging", "stlfr", "tellseq"]. The nonlinked_ok option controls whether
     the detection of "none" linked-read types is permissible, otherwise throwing an error.
     """

--- a/harpy/validation/sam.py
+++ b/harpy/validation/sam.py
@@ -40,7 +40,7 @@ class SAM():
             print_error(
                 "invalid characters",
                 "Invalid characters were detected in the input file names.",
-                "Valid file names may contain only:\n  - [green]A-Z[/] characters (case insensitive)\n  - [green].[/] (period)\n  - [green]_[/] (underscore)\n  - [green]-[/] (dash)",
+                "Valid file names may contain only:\n  - [green]A-Z 0-9[/] characters (case insensitive)\n  - [green].[/] (period)\n  - [green]_[/] (underscore)\n  - [green]-[/] (dash)",
                 "The offending files",
                 ", ".join(badmatch)
                 )

--- a/harpy/validation/sam.py
+++ b/harpy/validation/sam.py
@@ -57,8 +57,10 @@ class SAM():
                 dupe_out
             )
         if detect_bc:
-            for i in range(min(6, self.count)):
-                self.lr_type = which_linkedread_sam(self.files[i])
+            for i,samfile in enumerate(self.files):
+                if i > 5:
+                    break
+                self.lr_type = which_linkedread_sam(samfile)
                 if self.lr_type != "none":
                     break
             if not nonlinked_ok and self.lr_type == "none":

--- a/harpy/validation/sam.py
+++ b/harpy/validation/sam.py
@@ -2,7 +2,6 @@
 from itertools import chain
 import os
 import re
-from rich.markdown import Markdown
 from harpy.common.printing import print_error
 from harpy.validation.barcodes import which_linkedread_sam
 
@@ -41,7 +40,7 @@ class SAM():
             print_error(
                 "invalid characters",
                 "Invalid characters were detected in the input file names.",
-                Markdown("Valid file names may contain only:\n- **A-Z** characters (case insensitive)\n- **.** (period)\n- **_** (underscore)\n- **-** (dash)"),
+                "Valid file names may contain only:\n  - [green]A-Z[/] characters (case insensitive)\n  - [green].[/] (period)\n  - [green]_[/] (underscore)\n  - [green]-[/] (dash)",
                 "The offending files",
                 ", ".join(badmatch)
                 )
@@ -51,15 +50,17 @@ class SAM():
                 dupe_out.append(" ".join([j for j in self.files if i in j]))
             print_error(
                 "clashing sample names",
-                Markdown("Identical filenames were detected, which will cause unexpected behavior and results.\n- files with identical names but different-cased extensions are treated as identical\n- files with the same name from different directories are also considered identical"),
+                "Identical filenames were detected, which will cause unexpected behavior and results.\n  - files with identical names but different-cased extensions are treated as identical\n  - files with the same name from different directories are also considered identical",
                 "Make sure all input files have unique names.",
                 "Files with clashing names",
                 dupe_out
             )
         if detect_bc:
+            scanned = []
             for i,samfile in enumerate(self.files):
                 if i > 5:
                     break
+                scanned.append(os.path.basename(samfile))
                 self.lr_type = which_linkedread_sam(samfile)
                 if self.lr_type != "none":
                     break
@@ -67,5 +68,7 @@ class SAM():
                 print_error(
                     "incompatible data",
                     "This command requires linked-read data, but harpy was unable to associate the input data as being haplotagging, stlfr, or tellseq format. Autodetection scanned the first 100 lines of the first 5 files and failed to find barcodes conforming to those formatting standards.",
-                    "Please double-check that these data are indeed linked-read data and the barcodes are formatted according to that technology standard."
+                    "Please double-check that these data are indeed linked-read data and the barcodes are formatted according to that technology standard.",
+                    "Files scanned",
+                    "\n".join(scanned)
                 )


### PR DESCRIPTION
This PR introduces logic to perform a little sentinel checking to auto-detect linked-read types in FASTQ and BAM formats. This results in:
- removing the `--lr-type` option
- what used to be `--ignore-bx` and `--lr-type none` is not `--unlinked`
- fix formatting error in `convert fastq`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic linked‑read detection for FASTQ/SAM (haplotagging, stlfr, tellseq); Linked‑Read Type displayed in start/status.

* **Refactor**
  * Replaced lr‑type with opt‑out --unlinked across commands; barcode settings moved under a nested linkedreads config; BX/BC tag option removed from assembly.

* **Documentation**
  * CLI help and docstrings updated to explain auto‑detection and --unlinked.

* **Tests**
  * CI/test workflow updated to use --unlinked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->