### PR TITLE
tolerate intermediates for speedup

### DIFF
--- a/harpy/common/cli_params.py
+++ b/harpy/common/cli_params.py
@@ -34,38 +34,19 @@ class BwaParams(click.ParamType):
     """A class for a click type that validates bwa extra-params."""
     name = "bwa_params"
     def convert(self, value, param, ctx):
-        harpy_options = "-C -v -t -R".split()
-        valid_options = "-k -w -d -r -c -P -A -B -O -E -L -U -p -T -a -H -M ".split()
+        harpy_options = "-C -v -t -R -T -m".split()
+        valid_options = "-k -w -d -r -y -c -D -W -S -P -A -B -O -E -L -U -p -R -H -j -5 -q -K -h -a -V -Y -M -I".split()
         opts = 0
-        docs = "https://bio-bwa.sourceforge.net/bwa.shtml"
+        docs = "https://github.com/bwa-mem2/bwa-mem2"
         for i in shellsplit(value):
             if i.startswith("-"):
                 opts += 1
                 if i in harpy_options:
-                    self.fail(f"{i} is already used by Harpy when calling bwa mem.", param, ctx)
+                    self.fail(f"{i} is already used by Harpy when calling bwa-mem2 mem.", param, ctx)
                 if i not in valid_options:
-                    self.fail(f"{i} is not a valid bwa mem option. See the bwa documentation for a list of available options: {docs}.", param, ctx)
+                    self.fail(f"{i} is not a valid bwa-mem2 option. See the bwa documentation for a list of available options: {docs}.", param, ctx)
         if opts < 1:
-            self.fail(f"No valid options recognized. Available bwa options begin with one dash (e.g. -M). See the bwa documentation for a list of available options: {docs}.", param, ctx)
-        return sanitize_shell(value)
-
-class EmaParams(click.ParamType):
-    """A class for a click type that validates ema extra-params."""
-    name = "ema_params"
-    def convert(self, value, param, ctx):
-        harpy_options = "-t -p -d -r -R -x".split()
-        valid_options = "-i".split()
-        opts = 0
-        docs = "https://github.com/arshajii/ema"
-        for i in shellsplit(value):
-            if i.startswith("-"):
-                opts += 1
-                if i in harpy_options:
-                    self.fail(f"{i} is already used by Harpy when calling ema.", param, ctx)
-                if i not in valid_options:
-                    self.fail(f"{i} is not a valid ema option. See the ema documentation for a list of available options: {docs}.", param, ctx)
-        if opts < 1:
-            self.fail(f"No valid options recognized. Available ema options begin with one dash (e.g. -i). See the ema documentation for a list of available options: {docs}.", param, ctx)
+            self.fail(f"No valid options recognized. Available bwa-mem2 options begin with one dash (e.g. -M). See the bwa-mem2 documentation: {docs}.", param, ctx)
         return sanitize_shell(value)
 
 class StrobeAlignParams(click.ParamType):
@@ -470,3 +451,5 @@ class ImputeRegion(click.ParamType):
         if startpos > endpos:
             self.fail(f"The region start position ({startpos}) must be less than the end position ({endpos}).", param, ctx)
         return value
+
+

--- a/harpy/snakefiles/align_bwa.smk
+++ b/harpy/snakefiles/align_bwa.smk
@@ -85,7 +85,7 @@ rule align:
         "logs/bwa/{sample}.bwa.log"
     params:
         RG_tag = lambda wc: "-R \"@RG\\tID:" + wc.get("sample") + "\\tSM:" + wc.get("sample") + "\"",
-        static = "-m 10 -C -v 2 -T 10" if illumina_old else "-v 2 -T 10",
+        static = "-m 10 -C -v 2 -T 10" if illumina_old else "-v 2 -T 10 -m 10",
         extra = extra
     threads:
         4
@@ -126,9 +126,9 @@ rule sort:
         mkdir -p {resources.tmpdir}
         {{
             samtools fixmate -z on -m -u {input} - |
-            tee >(samtools stats -x - > {output.stats}) |
-            samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -u -l 0 -m {resources.mem_mb_per_thread}M -
-        }} 2> {log} > {output.bam}
+            samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -o {output.bam} -u -l 0 -m {resources.mem_mb_per_thread}M -
+            samtools stats -@ {params.sortthreads} -x {output.bam} > {output.stats} 
+        }} 2> {log}
         """
 
 rule mark_duplicates:

--- a/harpy/snakefiles/align_bwa.smk
+++ b/harpy/snakefiles/align_bwa.smk
@@ -120,7 +120,7 @@ rule sort:
         4
     resources:
         tmpdir = lambda wc: f"sort/{wc.sample}/tmp",
-        mem_mb_per_thread = lambda wc, threads, attempt: max(500, (3000 - (1000 * attempt)) // threads)
+        mem_mb_per_thread = lambda wc, attempt: 3000 // attempt
     shell:
         """
         mkdir -p {resources.tmpdir}

--- a/harpy/snakefiles/align_bwa.smk
+++ b/harpy/snakefiles/align_bwa.smk
@@ -157,7 +157,7 @@ rule mark_duplicates:
         {{
             samtools view -h -u -q {params.quality} {params.unmapped} {input.bam} |
             samtools markdup -@ {params.mdthreads} -T {resources.tmpdir} {params.bx_mode} -d $OPT -f {output.stats} - {output.bam}
-        }} 2> {log.debug}
+        }} 2> {log}
         """
 
 if lr_type != "none" and not (bx_tag and vx_tag):

--- a/harpy/snakefiles/align_bwa.smk
+++ b/harpy/snakefiles/align_bwa.smk
@@ -79,9 +79,8 @@ rule align:
         genome     = workflow_geno,
         genome_idx = multiext(workflow_geno, ".0123", ".amb", ".ann", ".bwt.2bit.64", ".pac")
     output:
-        sam = pipe("samples/{sample}/{sample}.bwa.sam"),
-        stats = "reports/data/samtools_stats/{sample}.raw.stats",
-        tmp = temp(directory("samples/{sample}/tmp"))
+        bam = temp("bwa/{sample}/{sample}.bwa.bam"),
+        tmp = temp(directory("bwa/{sample}/tmp"))
     log:
         "logs/bwa/{sample}.bwa.log"
     params:
@@ -89,9 +88,9 @@ rule align:
         static = "-C -v 2 -T 10" if illumina_old else "-v 2 -T 10",
         extra = extra
     threads:
-        max(1, min(4, workflow.cores - 2))
+        4
     resources:
-        tmpdir = lambda wc: f"samples/{wc.sample}/tmp"
+        tmpdir = lambda wc: f"bwa/{wc.sample}/tmp"
     conda:
         "envs/align.yaml"
     container:
@@ -100,40 +99,65 @@ rule align:
         """
         mkdir -p {resources.tmpdir}
         {{
-            bwa-mem2 mem -t {threads} {params.RG_tag} {params.static} {params.extra} {input.genome} {input.fastq} |
-                samtools collate -T {resources.tmpdir}/collate -O -u - |
-                samtools fixmate -z on -m -u - - |
-                tee >(samtools stats -x - > {output.stats})
-        }} 2> {log} > {output.sam}
+            bwa-mem2 mem -t {threads} {params} {input.genome} {input.fastq} |
+            samtools collate -T {resources.tmpdir} -O -u - 
+        }} 2> {log} > {output.bam}
+        rm -rf {resources.tmpdir}
+        """
+
+rule sort:
+    input:
+        "bwa/{sample}/{sample}.bwa.bam"
+    output:
+        bam = temp("sort/{sample}/{sample}.sort.bam"),
+        stats = "reports/data/samtools_stats/{sample}.raw.stats",
+        tmp = temp(directory("sort/{sample}/tmp"))
+    log:
+        "logs/sort/{sample}.sort.log"
+    params:
+        sortthreads = lambda wc, threads: threads - 1
+    threads:
+        4
+    resources:
+        tmpdir = lambda wc: f"sort/{wc.sample}/tmp",
+        mem_mb = lambda wc, threads: threads * 3000,
+    shell:
+        """
+        mkdir -p {resources.tmpdir}
+        {{
+            samtools fixmate -z on -m -u {input} - |
+            tee >(samtools stats -x - > {output.stats})
+            samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -u -l 0 -m {resources.mem_mb}M -
+        }} 2> {log} > {output.bam}
+        rm -rf {resources.tmpdir}
         """
 
 rule mark_duplicates:
     input:
         fq  = get_fq,
-        sam = "samples/{sample}/{sample}.bwa.sam"
+        bam = "sort/{sample}/{sample}.sort.bam"
     output:
         bam   = "{sample}.bam" if lr_type == "none" or (bx_tag and vx_tag) else temp("markdup/{sample}.bam"),
         stats = "reports/data/markdup/{sample}.markdup",
-        tmp = temp(directory("samples/{sample}/mdtmp"))
+        tmp = temp(directory("markdup/{sample}/tmp"))
     log:
-        debug = "logs/markdup/{sample}.markdup.log",
+        "logs/markdup/{sample}.markdup.log"
     params:
         bx_mode = "-S --barcode-tag BX" if not ignore_bx else "-S",
         quality = PARAMETERS.get('min-map-quality', 30),
         unmapped = "-F 4" if not keep_unmapped else "",
+        mdthreads = lambda wc, threads: threads - 1
     resources:
-        mem_mb = 2000,
-        tmpdir = lambda wc: f"samples/{wc.sample}/tmp"
+        tmpdir = lambda wc: f"makrdup/{wc.sample}/tmp"
     threads:
-        2
+        4
     shell:
         """
         mkdir -p {resources.tmpdir}
         OPT=$(harpy-utils optical-dist-fq {input.fq})
         {{
-            samtools view -h -u -q {params.quality} {params.unmapped} {input.sam} |
-            samtools sort -T {resources.tmpdir}/sort -u -l 0 -m {resources.mem_mb}M - |
-            samtools markdup -@ 1 -T {resources.tmpdir}/mkdup {params.bx_mode} -d $OPT -f {output.stats} - {output.bam}
+            samtools view -h -u -q {params.quality} {params.unmapped} {input.bam} |
+            samtools markdup -@ {params.mdthreads} -T {resources.tmpdir} {params.bx_mode} -d $OPT -f {output.stats} - {output.bam}
         }} 2> {log.debug}
         rm -rf {resources.tmpdir}
         """

--- a/harpy/snakefiles/align_bwa.smk
+++ b/harpy/snakefiles/align_bwa.smk
@@ -105,6 +105,7 @@ rule align:
         """
 
 rule sort:
+    retries: 3
     input:
         "bwa/{sample}/{sample}.bwa.bam"
     output:
@@ -119,14 +120,14 @@ rule sort:
         4
     resources:
         tmpdir = lambda wc: f"sort/{wc.sample}/tmp",
-        mem_mb = lambda wc, threads: threads * 3000,
+        mem_mb_per_thread = lambda wc, threads, attempt: max(500, (3000 - (1000 * attempt)) // threads)
     shell:
         """
         mkdir -p {resources.tmpdir}
         {{
             samtools fixmate -z on -m -u {input} - |
             tee >(samtools stats -x - > {output.stats}) |
-            samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -u -l 0 -m {resources.mem_mb}M -
+            samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -u -l 0 -m {resources.mem_mb_per_thread}M -
         }} 2> {log} > {output.bam}
         """
 
@@ -146,7 +147,7 @@ rule mark_duplicates:
         unmapped = "-F 4" if not keep_unmapped else "",
         mdthreads = lambda wc, threads: threads - 1
     resources:
-        tmpdir = lambda wc: f"makrdup/{wc.sample}/tmp"
+        tmpdir = lambda wc: f"markdup/{wc.sample}/tmp"
     threads:
         4
     shell:

--- a/harpy/snakefiles/align_bwa.smk
+++ b/harpy/snakefiles/align_bwa.smk
@@ -85,7 +85,7 @@ rule align:
         "logs/bwa/{sample}.bwa.log"
     params:
         RG_tag = lambda wc: "-R \"@RG\\tID:" + wc.get("sample") + "\\tSM:" + wc.get("sample") + "\"",
-        static = "-C -v 2 -T 10" if illumina_old else "-v 2 -T 10",
+        static = "-m 10 -C -v 2 -T 10" if illumina_old else "-v 2 -T 10",
         extra = extra
     threads:
         4

--- a/harpy/snakefiles/align_bwa.smk
+++ b/harpy/snakefiles/align_bwa.smk
@@ -102,7 +102,6 @@ rule align:
             bwa-mem2 mem -t {threads} {params} {input.genome} {input.fastq} |
             samtools collate -T {resources.tmpdir} -O -u - 
         }} 2> {log} > {output.bam}
-        rm -rf {resources.tmpdir}
         """
 
 rule sort:
@@ -129,7 +128,6 @@ rule sort:
             tee >(samtools stats -x - > {output.stats})
             samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -u -l 0 -m {resources.mem_mb}M -
         }} 2> {log} > {output.bam}
-        rm -rf {resources.tmpdir}
         """
 
 rule mark_duplicates:
@@ -159,7 +157,6 @@ rule mark_duplicates:
             samtools view -h -u -q {params.quality} {params.unmapped} {input.bam} |
             samtools markdup -@ {params.mdthreads} -T {resources.tmpdir} {params.bx_mode} -d $OPT -f {output.stats} - {output.bam}
         }} 2> {log.debug}
-        rm -rf {resources.tmpdir}
         """
 
 if lr_type != "none" and not (bx_tag and vx_tag):

--- a/harpy/snakefiles/align_bwa.smk
+++ b/harpy/snakefiles/align_bwa.smk
@@ -125,7 +125,7 @@ rule sort:
         mkdir -p {resources.tmpdir}
         {{
             samtools fixmate -z on -m -u {input} - |
-            tee >(samtools stats -x - > {output.stats})
+            tee >(samtools stats -x - > {output.stats}) |
             samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -u -l 0 -m {resources.mem_mb}M -
         }} 2> {log} > {output.bam}
         """

--- a/harpy/snakefiles/align_strobe.smk
+++ b/harpy/snakefiles/align_strobe.smk
@@ -81,7 +81,6 @@ rule align:
             strobealign {params} -t {threads} {input.genome} {input.fastq} |
             samtools collate -T {resources.tmpdir} -O -u -
         }} > {output.bam} 2> {log}
-        rm -rf {resources.tmpdir}
         """
 
 rule sort:
@@ -108,7 +107,6 @@ rule sort:
             tee >(samtools stats -x - > {output.stats})
             samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -u -l 0 -m {resources.mem_mb}M -
         }} 2> {log} > {output.bam}
-        rm -rf {resources.tmpdir}
         """
 
 rule mark_duplicates:
@@ -138,7 +136,6 @@ rule mark_duplicates:
             samtools view -h -u -q {params.quality} {params.unmapped} {input.bam} |
             samtools markdup -@ {params.mdthreads} -T {resources.tmpdir} {params.bx_mode} -d $OPT -f {output.stats} - {output.bam}
         }} 2> {log.debug}
-        rm -rf {resources.tmpdir}
         """
 
 if lr_type != "none" and not (bx_tag and vx_tag):

--- a/harpy/snakefiles/align_strobe.smk
+++ b/harpy/snakefiles/align_strobe.smk
@@ -79,8 +79,8 @@ rule align:
         mkdir -p {resources.tmpdir}
         {{
             strobealign {params} -t {threads} {input.genome} {input.fastq} |
-            samtools collate -T {resources.tmpdir} -o {output.bam} -u -l 0 -
-        }} 2> {log}
+            samtools collate -T {resources.tmpdir} -O -u -l 0 -
+        }} 2> {log} > {output.bam}
         """
 
 rule sort:

--- a/harpy/snakefiles/align_strobe.smk
+++ b/harpy/snakefiles/align_strobe.smk
@@ -84,7 +84,6 @@ rule align:
         rm -rf {resources.tmpdir}
         """
 
-
 rule sort:
     input:
         "strobealign/{sample}/{sample}.strobe.bam"

--- a/harpy/snakefiles/align_strobe.smk
+++ b/harpy/snakefiles/align_strobe.smk
@@ -99,7 +99,7 @@ rule sort:
         4
     resources:
         tmpdir = lambda wc: f"sort/{wc.sample}/tmp",
-        mem_mb_per_thread = lambda wc, threads, attempt: max(500, (3000 - (1000 * attempt)) // threads)
+        mem_mb_per_thread = lambda wc, attempt: 3000 // attempt
     shell:
         """
         mkdir -p {resources.tmpdir}

--- a/harpy/snakefiles/align_strobe.smk
+++ b/harpy/snakefiles/align_strobe.smk
@@ -84,6 +84,7 @@ rule align:
         """
 
 rule sort:
+    retries: 3
     input:
         "strobealign/{sample}/{sample}.strobe.bam"
     output:
@@ -98,14 +99,14 @@ rule sort:
         4
     resources:
         tmpdir = lambda wc: f"sort/{wc.sample}/tmp",
-        mem_mb = lambda wc, threads: threads * 2000,
+        mem_mb_per_thread = lambda wc, threads, attempt: max(500, (3000 - (1000 * attempt)) // threads)
     shell:
         """
         mkdir -p {resources.tmpdir}
         {{
             samtools fixmate -z on -m -u {input} - |
             tee >(samtools stats -x - > {output.stats}) |
-            samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -u -l 0 -m {resources.mem_mb}M -
+            samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -u -l 0 -m {resources.mem_mb_per_thread}M -
         }} 2> {log} > {output.bam}
         """
 
@@ -125,7 +126,7 @@ rule mark_duplicates:
         unmapped = "-F 4" if not keep_unmapped else "",
         mdthreads = lambda wc, threads: threads - 1
     resources:
-        tmpdir = lambda wc: f"makrdup/{wc.sample}/tmp"
+        tmpdir = lambda wc: f"markdup/{wc.sample}/tmp"
     threads:
         4
     shell:
@@ -135,7 +136,7 @@ rule mark_duplicates:
         {{
             samtools view -h -u -q {params.quality} {params.unmapped} {input.bam} |
             samtools markdup -@ {params.mdthreads} -T {resources.tmpdir} {params.bx_mode} -d $OPT -f {output.stats} - {output.bam}
-        }} 2> {log.debug}
+        }} 2> {log}
         """
 
 if lr_type != "none" and not (bx_tag and vx_tag):

--- a/harpy/snakefiles/align_strobe.smk
+++ b/harpy/snakefiles/align_strobe.smk
@@ -57,8 +57,8 @@ rule align:
         fastq = get_fq,
         genome = workflow_geno
     output:  
-        sam = pipe("samples/{sample}/{sample}.strobe.sam"),
-        stats = touch("reports/data/samtools_stats/{sample}.raw.stats")
+        bam = temp("strobealign/{sample}/{sample}.strobe.bam"),
+        tmp = temp(directory("strobealign/{sample}/tmp"))
     log:
         "logs/strobealign/{sample}.strobealign.log"
     params: 
@@ -67,9 +67,9 @@ rule align:
         RGsm = lambda wc: f"--rg=SM:{wc.get('sample')}",
         extra = extra
     threads:
-        max(1, min(4, workflow.cores - 2))
+        4
     resources:
-        tmpdir = lambda wc: f"samples/{wc.sample}/tmp"
+        tmpdir = lambda wc: f"strobealign/{wc.sample}/tmp"
     conda:
         "envs/align.yaml"
     container:
@@ -79,39 +79,66 @@ rule align:
         mkdir -p {resources.tmpdir}
         {{
             strobealign {params} -t {threads} {input.genome} {input.fastq} |
-                samtools collate -T {resources.tmpdir}/collate -O -u - |
-                samtools fixmate -z on -m -u - - |
-                tee >(samtools stats -x - > {output.stats})
-        }} > {output.sam} 2> {log}
+            samtools collate -T {resources.tmpdir} -O -u -
+        }} > {output.bam} 2> {log}
+        rm -rf {resources.tmpdir}
+        """
+
+
+rule sort:
+    input:
+        "strobealign/{sample}/{sample}.strobe.bam"
+    output:
+        bam = temp("sort/{sample}/{sample}.sort.bam"),
+        stats = "reports/data/samtools_stats/{sample}.raw.stats",
+        tmp = temp(directory("sort/{sample}/tmp"))
+    log:
+        "logs/sort/{sample}.sort.log"
+    params:
+        sortthreads = lambda wc, threads: threads - 1
+    threads:
+        4
+    resources:
+        tmpdir = lambda wc: f"sort/{wc.sample}/tmp",
+        mem_mb = lambda wc, threads: threads * 3000,
+    shell:
+        """
+        mkdir -p {resources.tmpdir}
+        {{
+            samtools fixmate -z on -m -u {input} - |
+            tee >(samtools stats -x - > {output.stats})
+            samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -u -l 0 -m {resources.mem_mb}M -
+        }} 2> {log} > {output.bam}
+        rm -rf {resources.tmpdir}
         """
 
 rule mark_duplicates:
     input:
         fq  = get_fq,
-        sam = "samples/{sample}/{sample}.strobe.sam",
+        bam = "sort/{sample}/{sample}.sort.bam"
     output:
         bam   = "{sample}.bam" if lr_type == "none" or (bx_tag and vx_tag) else temp("markdup/{sample}.bam"),
-        stats = "reports/data/markdup/{sample}.markdup"
+        stats = "reports/data/markdup/{sample}.markdup",
+        tmp = temp(directory("markdup/{sample}/tmp"))
     log:
         "logs/markdup/{sample}.markdup.log"
     params:
         bx_mode = "-S --barcode-tag BX" if not ignore_bx else "-S",
         quality = PARAMETERS.get('min-map-quality', 30),
         unmapped = "-F 4" if not keep_unmapped else "",
+        mdthreads = lambda wc, threads: threads - 1
     resources:
-        mem_mb = 2000,
-        tmpdir = lambda wc: f"samples/{wc.sample}/tmp"
+        tmpdir = lambda wc: f"makrdup/{wc.sample}/tmp"
     threads:
-        2
+        4
     shell:
         """
         mkdir -p {resources.tmpdir}
         OPT=$(harpy-utils optical-dist-fq {input.fq})
         {{
-            samtools view -h -u -q {params.quality} {params.unmapped} {input.sam} |
-            samtools sort -T {resources.tmpdir}/sort -u -l 0 -m {resources.mem_mb}M - |
-            samtools markdup -@ 1 -T {resources.tmpdir}/mkdup {params.bx_mode} -d $OPT -f {output.stats} - {output.bam}
-        }} 2> {log}
+            samtools view -h -u -q {params.quality} {params.unmapped} {input.bam} |
+            samtools markdup -@ {params.mdthreads} -T {resources.tmpdir} {params.bx_mode} -d $OPT -f {output.stats} - {output.bam}
+        }} 2> {log.debug}
         rm -rf {resources.tmpdir}
         """
 

--- a/harpy/snakefiles/align_strobe.smk
+++ b/harpy/snakefiles/align_strobe.smk
@@ -79,8 +79,8 @@ rule align:
         mkdir -p {resources.tmpdir}
         {{
             strobealign {params} -t {threads} {input.genome} {input.fastq} |
-            samtools collate -T {resources.tmpdir} -O -u -
-        }} > {output.bam} 2> {log}
+            samtools collate -T {resources.tmpdir} -o {output.bam} -u -l 0 -
+        }} 2> {log}
         """
 
 rule sort:
@@ -98,7 +98,7 @@ rule sort:
         4
     resources:
         tmpdir = lambda wc: f"sort/{wc.sample}/tmp",
-        mem_mb = lambda wc, threads: threads * 3000,
+        mem_mb = lambda wc, threads: threads * 2000,
     shell:
         """
         mkdir -p {resources.tmpdir}

--- a/harpy/snakefiles/align_strobe.smk
+++ b/harpy/snakefiles/align_strobe.smk
@@ -105,9 +105,9 @@ rule sort:
         mkdir -p {resources.tmpdir}
         {{
             samtools fixmate -z on -m -u {input} - |
-            tee >(samtools stats -x - > {output.stats}) |
-            samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -u -l 0 -m {resources.mem_mb_per_thread}M -
-        }} 2> {log} > {output.bam}
+            samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -o {output.bam} -u -l 0 -m {resources.mem_mb_per_thread}M -
+            samtools stats -@ {params.sortthreads} -x {output.bam} > {output.stats} 
+        }} 2> {log}
         """
 
 rule mark_duplicates:

--- a/harpy/snakefiles/align_strobe.smk
+++ b/harpy/snakefiles/align_strobe.smk
@@ -104,7 +104,7 @@ rule sort:
         mkdir -p {resources.tmpdir}
         {{
             samtools fixmate -z on -m -u {input} - |
-            tee >(samtools stats -x - > {output.stats})
+            tee >(samtools stats -x - > {output.stats}) |
             samtools sort -@ {params.sortthreads} -T {resources.tmpdir} -u -l 0 -m {resources.mem_mb}M -
         }} 2> {log} > {output.bam}
         """


### PR DESCRIPTION
This update changes the main align logic to use intermediate uncompressed bam files instead of relying on pipes, which should result in a balance of disk burden and speed. Additionally, gives samtools sort thread-scaled memory allocations so it goes faster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured alignment pipelines into separate, dedicated stages for better organization.
  * Transitioned intermediate alignment outputs from SAM to BAM format for optimized processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->